### PR TITLE
feat: add NO_VERSION alert for issues past Backlog without a Version value

### DIFF
--- a/.github/workflows/sync-project-reporting-metrics.md
+++ b/.github/workflows/sync-project-reporting-metrics.md
@@ -2,12 +2,12 @@
 
 ## What it does
 
-This is an **automation workflow** designed to facilitate **progress reporting and sync across multiple GitHub Projects**. It runs **once daily at 00:00 UTC** and checks **all items across all configured projects**. For each item it compares the current values of the five tracked fields (**Status**, **Priority**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
+This is an **automation workflow** designed to facilitate **progress reporting and sync across multiple GitHub Projects**. It runs **once daily at 00:00 UTC** and checks **all items across all configured projects**. For each item it compares the current values of the tracked fields (**Status**, **Priority**, **Version**, **Estimate**, **Remaining Work**, **Time Spent**) against the last entry in the item's **`Reporting Log`** field. If a change is detected (or the log is empty), the workflow:
 
 1. Sets **`Reporting Date`** to today
 2. Prepends a new entry to **`Reporting Log`** in the format:
    ```
-   YYYY-MM-DD, Area, Status, Priority, Estimate, Remaining Work, Time Spent
+   YYYY-MM-DD, Area, Status, Priority, Version, Estimate, Remaining Work, Time Spent
    ```
 3. (Optional) Syncs **Priority**, **Estimate**, **Remaining Work**, and **Time Spent** to the linked JIRA ticket
 
@@ -25,8 +25,9 @@ In every GitHub Project you want to track, make sure the following fields exist 
 
 | Field name           | Type          | Notes                                                                                     |
 |----------------------|---------------|-------------------------------------------------------------------------------------------|
-| `Status`             | Single select | e.g. Backlog, In Progress, Done                                                           |
-| `Priority`           | Single select | e.g. Low, Medium, High                                                                    |
+| `Status`             | Single select | e.g. Backlog, Next, In Progress, In Review, Done                                                           |
+| `Priority`           | Single select | e.g. `Blocker`, `Critical`, `Major`, `Normal`, `Minor`                                    |
+| `Version`            | Text          | Target release version (e.g. `3.20`, `2025.Q2`) |
 | `Estimate`           | Number        | Estimated effort in weeks (e.g. `2` = 2 weeks, `0.4` = 2 days, `0.1` = 4 hours)         |
 | `Remaining Work`     | Number        | Remaining effort in weeks                                                                 |
 | `Time Spent`         | Number        | Time already spent in weeks                                                               |
@@ -71,12 +72,12 @@ On subsequent runs the item is treated as a normal JIRA-synced issue. Requires t
 **Reporting Log entry format** — entries are separated by ` | `, ordered **newest first**:
 
 ```
-DATE, Area, Status, Priority, Estimate, Remaining Work, Time Spent
+DATE, Area, Status, Priority, Version, Estimate, Remaining Work, Time Spent
 ```
 
 Example (newest → oldest, max 5 entries):
 ```
-2026-03-10, CI, In Progress, High, 8, 5, 3 | 2026-03-01, CI, Backlog, High, 8, 8, 0
+2026-03-10, CI, In Progress, Major, 3.20, 8, 5, 3 | 2026-03-01, CI, Backlog, Major, 3.20, 8, 8, 0
 ```
 
 #### Alerts codes
@@ -89,6 +90,7 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 | `NO_REMAINING_WORK` | `Remaining Work` is empty and `Status` is `In Progress` or `In Review` (not raised for `Done` — field is auto-cleared) |
 | `NO_AREA` | `Area` is empty and `Status` is not `Backlog` |
 | `NO_PRIORITY` | `Priority` is empty and `Status` is not `Backlog` |
+| `NO_VERSION` | `Version` is empty and `Status` is not `Backlog` |
 | `NO_TIME_SPENT` | `Time Spent` is empty and `Status` is `Done` |
 | `NO_ASSIGNEE` | Issue has no assignee and `Status` is `In Progress`, `In Review`, or `Done` |
 | `JIRA_NOT_FOUND` | `External Reference` is set but the JIRA ticket returned HTTP 404 |
@@ -201,7 +203,7 @@ For JIRA sync testing also:
 ### Testing steps
 
 1. **Go to a project** listed in your `PROJECTS` variable and pick any issue/item
-2. **Change one of the tracked fields**: Status, Priority, Estimate, Remaining Work, or Time Spent
+2. **Change one of the tracked fields**: Status, Priority, Version, Estimate, Remaining Work, or Time Spent
 3. **Trigger the workflow** manually (see above) or wait for 05:00 UTC
 4. **Check the Actions log** → open the latest run of `Sync Project Reporting Metrics`. You should see:
    - A `========` header per project with the org and project number
@@ -209,7 +211,7 @@ For JIRA sync testing also:
    - A per-project summary and a grand total at the end
 5. **Verify the project item**:
    - `Reporting Date` is set to today
-   - `Reporting Log` has a new entry prepended (`YYYY-MM-DD, Area, Status, Priority, Estimate, Remaining Work, Time Spent`), max 5 entries total separated by ` | `
+   - `Reporting Log` has a new entry prepended (`YYYY-MM-DD, Area, Status, Priority, Version, Estimate, Remaining Work, Time Spent`), max 5 entries total separated by ` | `
    - `Alerts` (if the field exists) is empty when all validation rules pass, or contains one or more codes (e.g. `NO_ESTIMATE`) when a rule is violated
 6. **Verify JIRA sync (if configured)** on the linked ticket:
    - The Actions log shows `Syncing to JIRA ticket: <id>` (confirming the `gh-issue-<number>` label is present)

--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -97,25 +97,27 @@ jobs:
               REMAINING_WORK=$(get_field "$item" "Remaining Work")
               TIME_SPENT=$(get_field     "$item" "Time Spent")
               AREA=$(get_field           "$item" "Area")
+              VERSION=$(get_field        "$item" "Version")
               REPORTING_LOG=$(get_field  "$item" "Reporting Log")
 
               # Parse tracked field values from the latest (first) entry in the log.
-              # Log format: ENTRY1 | ENTRY2 | ... where each entry is DATE, AREA, STATUS, PRIORITY, ESTIMATE, REMAINING_WORK, TIME_SPENT
+              # Log format: ENTRY1 | ENTRY2 | ... where each entry is DATE, AREA, STATUS, PRIORITY, VERSION, ESTIMATE, REMAINING_WORK, TIME_SPENT
               if [ -z "$REPORTING_LOG" ]; then
-                LAST_AREA="" LAST_STATUS="" LAST_PRIORITY="" LAST_ESTIMATE=""
-                LAST_REMAINING_WORK="" LAST_TIME_SPENT=""
+                LAST_AREA="" LAST_STATUS="" LAST_PRIORITY="" LAST_VERSION=""
+                LAST_ESTIMATE="" LAST_REMAINING_WORK="" LAST_TIME_SPENT=""
               else
                 LAST_ENTRY=$(echo "$REPORTING_LOG" | sed 's/ | /\n/g' | head -1)
                 LAST_AREA=$(echo           "$LAST_ENTRY" | cut -d',' -f2 | xargs)
                 LAST_STATUS=$(echo         "$LAST_ENTRY" | cut -d',' -f3 | xargs)
                 LAST_PRIORITY=$(echo       "$LAST_ENTRY" | cut -d',' -f4 | xargs)
-                LAST_ESTIMATE=$(echo       "$LAST_ENTRY" | cut -d',' -f5 | xargs)
-                LAST_REMAINING_WORK=$(echo "$LAST_ENTRY" | cut -d',' -f6 | xargs)
-                LAST_TIME_SPENT=$(echo     "$LAST_ENTRY" | cut -d',' -f7 | xargs)
+                LAST_VERSION=$(echo        "$LAST_ENTRY" | cut -d',' -f5 | xargs)
+                LAST_ESTIMATE=$(echo       "$LAST_ENTRY" | cut -d',' -f6 | xargs)
+                LAST_REMAINING_WORK=$(echo "$LAST_ENTRY" | cut -d',' -f7 | xargs)
+                LAST_TIME_SPENT=$(echo     "$LAST_ENTRY" | cut -d',' -f8 | xargs)
               fi
 
-              echo "  Current : $AREA, $STATUS, $PRIORITY, $ESTIMATE, $REMAINING_WORK, $TIME_SPENT"
-              echo "  Last log: $LAST_AREA, $LAST_STATUS, $LAST_PRIORITY, $LAST_ESTIMATE, $LAST_REMAINING_WORK, $LAST_TIME_SPENT"
+              echo "  Current : $AREA, $STATUS, $PRIORITY, $VERSION, $ESTIMATE, $REMAINING_WORK, $TIME_SPENT"
+              echo "  Last log: $LAST_AREA, $LAST_STATUS, $LAST_PRIORITY, $LAST_VERSION, $LAST_ESTIMATE, $LAST_REMAINING_WORK, $LAST_TIME_SPENT"
 
               # Read External Reference early — needed both for CREATE handling and JIRA sync
               EXTERNAL_REF=$(get_field "$item" "External Reference")
@@ -190,19 +192,22 @@ jobs:
                   fi
                 fi
               fi
-              if [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ -z "$ESTIMATE" ]; then
+              if [ -n "$ESTIMATE_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ -z "$ESTIMATE" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_ESTIMATE"
               fi
-              if [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ "$STATUS_LC" != "done" ] && [ -z "$REMAINING_WORK" ]; then
+              if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ "$STATUS_LC" != "done" ] && [ -z "$REMAINING_WORK" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
               fi
-              if [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$AREA" ]; then
+              if [ -n "$AREA_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$AREA" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_AREA"
               fi
-              if [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$PRIORITY" ]; then
+              if [ -n "$PRIORITY_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$PRIORITY" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_PRIORITY"
               fi
-              if [ "$STATUS_LC" = "done" ] && [ -z "$TIME_SPENT" ]; then
+              if [ -n "$VERSION_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$VERSION" ]; then
+                SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_VERSION"
+              fi
+              if [ -n "$TIME_SPENT_FIELD_ID" ] && [ "$STATUS_LC" = "done" ] && [ -z "$TIME_SPENT" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_TIME_SPENT"
               fi
               # Auto-clear Remaining Work for any Done item that still has a value (zero or non-zero).
@@ -256,6 +261,7 @@ jobs:
               if [ "$AREA"           = "$LAST_AREA"           ] && \
                  [ "$STATUS"         = "$LAST_STATUS"         ] && \
                  [ "$PRIORITY"        = "$LAST_PRIORITY"        ] && \
+                 [ "$VERSION"         = "$LAST_VERSION"         ] && \
                  [ "$ESTIMATE"        = "$LAST_ESTIMATE"        ] && \
                  [ "$REMAINING_WORK"  = "$LAST_REMAINING_WORK"  ] && \
                  [ "$TIME_SPENT"      = "$LAST_TIME_SPENT"      ]; then
@@ -281,7 +287,7 @@ jobs:
               echo "  → Change detected. Updating 'Reporting Date' and prepending to 'Reporting Log'."
 
               # Build new entry: DATE, AREA, STATUS, PRIORITY, ESTIMATE, REMAINING_WORK, TIME_SPENT
-              NEW_ENTRY="${TODAY}, ${AREA}, ${STATUS}, ${PRIORITY}, ${ESTIMATE}, ${REMAINING_WORK}, ${TIME_SPENT}"
+              NEW_ENTRY="${TODAY}, ${AREA}, ${STATUS}, ${PRIORITY}, ${VERSION}, ${ESTIMATE}, ${REMAINING_WORK}, ${TIME_SPENT}"
 
               # Prepend new entry and keep at most 5 entries total (discard oldest)
               if [ -z "$REPORTING_LOG" ]; then
@@ -604,7 +610,12 @@ jobs:
             REPORTING_LOG_FIELD_ID=$(echo "$PAGE_RESPONSE"  | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Reporting Log")     | .id')
             SYNC_STATUS_FIELD_ID=$(echo "$PAGE_RESPONSE"    | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Alerts")             | .id')
             EXTERNAL_REF_FIELD_ID=$(echo "$PAGE_RESPONSE"  | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "External Reference") | .id')
+            AREA_FIELD_ID=$(echo "$PAGE_RESPONSE"           | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Area")              | .id')
+            PRIORITY_FIELD_ID=$(echo "$PAGE_RESPONSE"       | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Priority")          | .id')
+            ESTIMATE_FIELD_ID=$(echo "$PAGE_RESPONSE"       | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Estimate")          | .id')
             REMAINING_WORK_FIELD_ID=$(echo "$PAGE_RESPONSE" | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Remaining Work")     | .id')
+            TIME_SPENT_FIELD_ID=$(echo "$PAGE_RESPONSE"     | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Time Spent")        | .id')
+            VERSION_FIELD_ID=$(echo "$PAGE_RESPONSE"        | jq -r '.data.organization.projectV2.fields.nodes[] | select(.name == "Version")            | .id')
 
             if [ -z "$REPORTING_DATE_FIELD_ID" ]; then
               echo "Error: 'Reporting Date' field not found in project $PROJECT_OWNER #$PROJECT_NUMBER. Skipping."
@@ -626,7 +637,12 @@ jobs:
             echo "Reporting Log field ID : $REPORTING_LOG_FIELD_ID"
             echo "Alerts field ID        : ${SYNC_STATUS_FIELD_ID:-not configured}"
             echo "External Ref field ID  : ${EXTERNAL_REF_FIELD_ID:-not configured}"
+            echo "Area field ID          : ${AREA_FIELD_ID:-not configured}"
+            echo "Priority field ID      : ${PRIORITY_FIELD_ID:-not configured}"
+            echo "Estimate field ID      : ${ESTIMATE_FIELD_ID:-not configured}"
             echo "Remaining Work field ID: ${REMAINING_WORK_FIELD_ID:-not configured}"
+            echo "Time Spent field ID    : ${TIME_SPENT_FIELD_ID:-not configured}"
+            echo "Version field ID       : ${VERSION_FIELD_ID:-not configured}"
 
             PAGE=1
 

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -24,7 +24,8 @@ You never need to trigger it manually. The workflow takes care of everything aut
 | Field | Type | What to enter |
 |-------|------|---------------|
 | `Status` | Single select | Lifecycle stage (see below) |
-| `Priority` | Single select | `Low`, `Medium`, `High`, `Critical` (or as configured) |
+| `Priority` | Single select | `Blocker`, `Critical`, `Major`, `Normal`, `Minor` |
+| `Version` | Text | Target release version (e.g. `3.20`, `2025.Q2`) |
 | `Estimate` | Number | Total effort in **weeks** — e.g. `2` = 2 weeks, `0.4` = 2 days, `0.1` = 4 hours |
 | `Remaining Work` | Number | Remaining effort in weeks, same unit as Estimate |
 | `Time Spent` | Number | Actual time logged so far, in weeks |
@@ -59,6 +60,7 @@ The issue is queued for the next sprint or cycle. At this point you should start
 |-------|-----------|-----|
 | `Area` | **Yes** | Alerts: `NO_AREA` |
 | `Priority` | **Yes** | Alerts: `NO_PRIORITY` |
+| `Version` | **Yes** | Alerts: `NO_VERSION` |
 | `Estimate` | Recommended | Will be required when the issue moves forward |
 | `Remaining Work` | Recommended | Same |
 
@@ -72,6 +74,7 @@ The issue is actively being worked on. All planning fields must be filled in and
 |-------|-----------|-----|
 | `Area` | **Yes** | Alerts: `NO_AREA` |
 | `Priority` | **Yes** | Alerts: `NO_PRIORITY` |
+| `Version` | **Yes** | Alerts: `NO_VERSION` |
 | `Estimate` | **Yes** | Alerts: `NO_ESTIMATE` |
 | `Remaining Work` | **Yes** | Alerts: `NO_REMAINING_WORK` |
 | `Time Spent` | Update regularly | Will be required at `Done` |
@@ -89,6 +92,7 @@ Same requirements as `In Progress`. Ensure `Remaining Work` reflects any remaini
 |-------|-----------|
 | `Area` | **Yes** |
 | `Priority` | **Yes** |
+| `Version` | **Yes** |
 | `Estimate` | **Yes** |
 | `Remaining Work` | **Yes** |
 | Assignee | **Yes** |
@@ -103,6 +107,7 @@ The issue is complete. Before closing it:
 |-------|-----------|-----|
 | `Area` | **Yes** | Alerts: `NO_AREA` |
 | `Priority` | **Yes** | Alerts: `NO_PRIORITY` |
+| `Version` | **Yes** | Alerts: `NO_VERSION` |
 | `Estimate` | **Yes** | Alerts: `NO_ESTIMATE` |
 | `Remaining Work` | **Auto-cleared** | The workflow sets this to empty automatically when the issue reaches `Done` |
 | `Time Spent` | **Yes** | Alerts: `NO_TIME_SPENT` |
@@ -118,6 +123,7 @@ Fill in the total `Time Spent` before or when you move the issue to `Done`. `Rem
 |-------|:-------:|:----:|:-----------:|:---------:|:----:|
 | Area | — | Required | Required | Required | Required |
 | Priority | — | Required | Required | Required | Required |
+| Version | — | Required | Required | Required | Required |
 | Estimate | — | Recommended | Required | Required | Required |
 | Remaining Work | — | Recommended | Required | Required | Auto-cleared |
 | Time Spent | — | — | Update often | Update often | Required |
@@ -151,6 +157,7 @@ The `Alerts` field is updated on every workflow run. An empty value means everyt
 |------|--------------|------------|
 | `NO_AREA` | `Area` is empty and the issue is past `Backlog` | Set the `Area` field |
 | `NO_PRIORITY` | `Priority` is empty and the issue is past `Backlog` | Set the `Priority` field |
+| `NO_VERSION` | `Version` is empty and the issue is past `Backlog` | Set the `Version` field |
 | `NO_ESTIMATE` | `Estimate` is empty and status is past `Next` | Set the `Estimate` field |
 | `NO_REMAINING_WORK` | `Remaining Work` is empty and status is `In Progress` or `In Review` | Set the `Remaining Work` field |
 | `NO_TIME_SPENT` | `Time Spent` is empty and status is `Done` | Enter the total time spent |
@@ -177,14 +184,14 @@ To clear `CHILDREN_STATUS`: update the child issues so their statuses align with
 Every time a tracked field changes, the workflow adds a new line to `Reporting Log`:
 
 ```
-YYYY-MM-DD, Area, Status, Priority, Estimate, Remaining Work, Time Spent
+YYYY-MM-DD, Area, Status, Priority, Version, Estimate, Remaining Work, Time Spent
 ```
 
 Entries are ordered **newest first**, separated by ` | `. A maximum of 5 entries are kept — older ones are dropped automatically.
 
 Example:
 ```
-2026-03-10, CI, In Progress, High, 2, 1, 1 | 2026-03-01, CI, Next, High, 2, 2, 0 | 2026-02-15, , Backlog, , , ,
+2026-03-10, CI, In Progress, Major, 3.20, 2, 1, 1 | 2026-03-01, CI, Next, Major, 3.20, 2, 2, 0 | 2026-02-15, , Backlog, , , , ,
 ```
 
 This is read-only from a user perspective — the workflow manages it entirely.


### PR DESCRIPTION
## Summary

- Looks up `VERSION_FIELD_ID` from project field metadata at startup (same pattern as other optional fields)
- Logs it in the project summary header
- Reads the `Version` field value per item via `get_field`
- Raises `NO_VERSION` when `Status != backlog` and `Version` is empty — only if `VERSION_FIELD_ID` is set (projects without the field are silently skipped)
- Operator guide and user guide updated with the new alert code

## Test plan

- [ ] Run against a project with a `Version` field — verify `NO_VERSION` fires for non-Backlog items with empty Version
- [ ] Verify `NO_VERSION` does not fire for Backlog items
- [ ] Run against a project without a `Version` field — verify no errors and no spurious alerts

Closes #15