### PR TITLE
fix: update JIRA auth to Atlassian Cloud Basic auth

### DIFF
--- a/.github/workflows/sync-project-reporting-metrics.md
+++ b/.github/workflows/sync-project-reporting-metrics.md
@@ -141,7 +141,8 @@ The workflow reads its project list and JIRA host from **GitHub Actions Variable
 | Variable name   | Example value               | Description |
 |-----------------|-----------------------------|-------------|
 | `PSYNC_PROJECTS`      | `orgA:1 orgB:3` | Space-separated `owner:project_number` pairs |
-| `PSYNC_JIRA_BASE_URL` | `https://issues.org.com` | Base URL of the JIRA instance (no trailing slash) |
+| `PSYNC_JIRA_BASE_URL` | `https://redhat.atlassian.net` | Base URL of the JIRA instance (no trailing slash) |
+| `PSYNC_JIRA_EMAIL`    | `user@redhat.com` | Atlassian account email used for JIRA API authentication |
 
 **`PSYNC_PROJECTS` format:** each entry is `<org>:<project-number>`, separated by spaces. The project number is the integer in the project URL: `https://github.com/orgs/<org>/projects/<number>`.
 
@@ -154,13 +155,14 @@ orgA:1 orgA:2 orgB:5
 
 ### 5. (Optional) Configure JIRA sync
 
-If you want changes to be synced to JIRA tickets, ensure the `External Reference` field is added to each project (step 1), then store one additional secret:
+If you want changes to be synced to JIRA tickets, ensure the `External Reference` field is added to each project (step 1), then configure the following:
 
-1. Generate a JIRA Personal Access Token in JIRA at **Profile → Personal Access Tokens → Create token**
+1. Generate an Atlassian Cloud API token at **[https://id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)**
 2. Go to **`Repository` → Settings → Secrets and variables → Actions → New repository secret**
-3. Set **Name** to `PSYNC_PAT_JIRA` and paste the token as the **Secret**
+3. Set **Name** to `PSYNC_PAT_JIRA` and paste the API token as the **Secret**
+4. Go to **Variables tab** and add `PSYNC_JIRA_EMAIL` set to the Atlassian account email that owns the token (e.g. `user@redhat.com`)
 
-> **Note:** JIRA Data Center (e.g. `issues.org.com`) uses PAT-based Bearer token authentication. Basic auth (username + password/API key) is not supported.
+> **Note:** Atlassian Cloud uses HTTP Basic authentication (`email:api_token`). The workflow computes the `Authorization: Basic ...` header automatically from `PSYNC_JIRA_EMAIL` and `PSYNC_PAT_JIRA`.
 
 When `External Reference` is set on a project item (e.g. `ISSUE-774`), the workflow will sync to the JIRA ticket **only if the following condition is met**:
 
@@ -185,12 +187,13 @@ Once all steps are done, the workflow runs automatically once daily (00:00 UTC) 
 
 - `PSYNC_PAT_GH` secret is set (PAT with `project` and `read:org` scopes)
 - `PSYNC_PROJECTS` variable is set (e.g. `orgA:1`) — **Settings → Secrets and variables → Actions → Variables**
-- `PSYNC_JIRA_BASE_URL` variable is set (e.g. `https://issues.org.com`) — same location
+- `PSYNC_JIRA_BASE_URL` variable is set (e.g. `https://redhat.atlassian.net`) — same location
 - Each project in `PSYNC_PROJECTS` has `Reporting Date` and `Reporting Log` fields
 - (Optional) Each project has a `Alerts` Text field to see validation codes
 
 For JIRA sync testing also:
-- `PSYNC_PAT_JIRA` secret is set
+- `PSYNC_PAT_JIRA` secret is set (Atlassian Cloud API token)
+- `PSYNC_JIRA_EMAIL` variable is set (Atlassian account email that owns the token)
 - The project has an `External Reference` field with a valid ticket ID on at least one item
 - The referenced JIRA ticket has the label `gh-issue-<number>` (e.g. `gh-issue-3` for GH issue #3)
 
@@ -244,7 +247,7 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **`Alerts` shows `JIRA_SYNC_ERROR HTTP_<code>`** → a JIRA API call failed; check the Actions log for the response body and consult the JIRA troubleshooting entries below
 - **`Alerts` shows `CHILDREN_STATUS`** → resolve the status inconsistency: if the parent is `Done`, all children must also be `Done`; if the parent is active (not `Backlog`/`Next`), no child should still be in `Backlog`
 - **JIRA sync skipped with "does not have the 'gh-issue-<number>' label"** → add the label `gh-issue-<number>` to the JIRA ticket to opt it in to syncing
-- **JIRA update failed (HTTP 401)** → `PSYNC_PAT_JIRA` is missing, expired, or is not a JIRA PAT; basic auth is not supported on JIRA Data Center
+- **JIRA update failed (HTTP 401)** → `PSYNC_PAT_JIRA` is missing or expired, or `PSYNC_JIRA_EMAIL` is wrong; Atlassian Cloud uses Basic auth (`email:api_token`) — verify both are correctly configured
 - **JIRA update failed (HTTP 404)** → the ticket ID in `External Reference` does not exist or is not accessible with the provided credentials
 - **JIRA update failed (HTTP 400)** → a field value is in an unexpected format (e.g. Priority name doesn't match a valid JIRA priority, or time values are not in the expected format)
 

--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -13,6 +13,7 @@ on:
 
 # Requires a PAT with 'project' and 'read:org' scopes stored as secret PSYNC_PAT_GH.
 # The default GITHUB_TOKEN does not have write access to organization-level projects.
+# JIRA Cloud (Atlassian) uses Basic auth: PSYNC_JIRA_EMAIL (account email) + PSYNC_PAT_JIRA (API token).
 
 jobs:
   track-reporting-date:
@@ -21,6 +22,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.PSYNC_PAT_GH }}
       JIRA_API_TOKEN: ${{ secrets.PSYNC_PAT_JIRA }}
+      JIRA_EMAIL: ${{ vars.PSYNC_JIRA_EMAIL }}
       JIRA_BASE_URL: ${{ vars.PSYNC_JIRA_BASE_URL }}
       PROJECTS: ${{ vars.PSYNC_PROJECTS }}
     steps:
@@ -32,6 +34,10 @@ jobs:
           trap 'rm -f /tmp/jira_create.json /tmp/jira_issue.json /tmp/jira_resp.json /tmp/jira_wl_list.json /tmp/jira_wl.json' EXIT
 
           TODAY=$(date -u +%Y-%m-%d)
+
+          # Atlassian Cloud uses HTTP Basic auth: base64(email:api_token).
+          # Computed once here and reused for all JIRA API calls.
+          JIRA_AUTH_HEADER="Basic $(printf '%s:%s' "$JIRA_EMAIL" "$JIRA_API_TOKEN" | base64 -w 0)"
 
           # Convert a GH numeric value (in weeks) to JIRA time format.
           # Convention: 1 week = 5 days = 40 hours.
@@ -160,7 +166,7 @@ jobs:
                       } + (if $comp != "" then {components: [{name: $comp}]} else {} end))
                     }')
                   JIRA_CREATE_HTTP=$(curl -s --max-time 30 -o /tmp/jira_create.json -w "%{http_code}" \
-                    -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                    -H "Authorization: ${JIRA_AUTH_HEADER}" \
                     -H "Content-Type: application/json" \
                     -X POST \
                     -d "$JIRA_CREATE_PAYLOAD" \
@@ -329,7 +335,7 @@ jobs:
 
                 # Fetch JIRA issue upfront to verify sync conditions before making any changes
                 JIRA_GET_STATUS=$(curl -s --max-time 30 -o /tmp/jira_issue.json -w "%{http_code}" \
-                  -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                  -H "Authorization: ${JIRA_AUTH_HEADER}" \
                   "${JIRA_ISSUE_URL}")
                 JIRA_GET_STATUS="${JIRA_GET_STATUS:-000}"
 
@@ -387,7 +393,7 @@ jobs:
                       }')
 
                     HTTP_STATUS=$(curl -s --max-time 30 -o /tmp/jira_resp.json -w "%{http_code}" \
-                      -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                      -H "Authorization: ${JIRA_AUTH_HEADER}" \
                       -X PUT \
                       -H "Content-Type: application/json" \
                       -d "$JIRA_PAYLOAD" \
@@ -421,7 +427,7 @@ jobs:
                       # Step 1: look for the managed worklog (identified by the copy comment or the legacy
                       # comment from earlier workflow versions) and try to update it in place.
                       WL_LIST_STATUS=$(curl -s --max-time 30 -o /tmp/jira_wl_list.json -w "%{http_code}" \
-                        -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                        -H "Authorization: ${JIRA_AUTH_HEADER}" \
                         "${JIRA_ISSUE_URL}/worklog")
                       WL_LIST_STATUS="${WL_LIST_STATUS:-000}"
                       echo "  → GET worklogs HTTP $WL_LIST_STATUS"
@@ -435,7 +441,7 @@ jobs:
                           WL_PAYLOAD=$(jq -n --arg ts "$JIRA_TIME_SPENT" --arg c "$WL_COPY_COMMENT" \
                             '{timeSpent: $ts, comment: $c}')
                           WL_STATUS=$(curl -s --max-time 30 -o /tmp/jira_wl.json -w "%{http_code}" \
-                            -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                            -H "Authorization: ${JIRA_AUTH_HEADER}" \
                             -X PUT \
                             -H "Content-Type: application/json" \
                             -d "$WL_PAYLOAD" \
@@ -479,7 +485,7 @@ jobs:
                           WL_PAYLOAD=$(jq -n --arg ts "$DELTA_JIRA" --arg c "$WL_COMMENT" \
                             '{timeSpent: $ts, comment: $c}')
                           WL_STATUS=$(curl -s --max-time 30 -o /tmp/jira_wl.json -w "%{http_code}" \
-                            -H "Authorization: Bearer ${JIRA_API_TOKEN}" \
+                            -H "Authorization: ${JIRA_AUTH_HEADER}" \
                             -X POST \
                             -H "Content-Type: application/json" \
                             -d "$WL_PAYLOAD" \


### PR DESCRIPTION
## Summary

Atlassian Cloud (`redhat.atlassian.net`) uses HTTP Basic authentication — `base64(email:api_token)` — instead of the Bearer token used by JIRA Data Center.

- Adds `JIRA_EMAIL` env var sourced from new `PSYNC_JIRA_EMAIL` variable
- Computes `JIRA_AUTH_HEADER` once at startup as `Basic base64(email:token)`
- Replaces all `Authorization: Bearer` curl calls with `Authorization: ${JIRA_AUTH_HEADER}`
- Updates operator guide: new `PSYNC_JIRA_EMAIL` variable documented in setup table, step 5, prerequisites, and troubleshooting; example URL updated to `https://redhat.atlassian.net`

## Manual steps required after merge

- [ ] Create `PSYNC_JIRA_EMAIL` repository variable with the Atlassian account email
- [ ] Update `PSYNC_PAT_JIRA` secret with a new Atlassian Cloud API token (from `id.atlassian.com`)
- [ ] Update `PSYNC_JIRA_BASE_URL` variable to `https://redhat.atlassian.net`

Closes #19