### PR TITLE
feat: report workflow errors as GitHub issues

### DIFF
--- a/.github/workflows/sync-project-reporting-metrics.md
+++ b/.github/workflows/sync-project-reporting-metrics.md
@@ -175,6 +175,14 @@ When this condition passes, the workflow will:
 
 If `PSYNC_PAT_JIRA` is not set, the JIRA sync step is skipped silently.
 
+### 6. Error notifications via GitHub issues
+
+When errors occur during a run (JIRA sync failures, GraphQL errors, unresolvable project IDs), the workflow automatically opens a GitHub issue in this repository titled **`bug: Error during project(s) sync workflow run`**. If an issue with that title is already open, a new comment is added instead of opening a duplicate.
+
+When a subsequent run completes without errors, the open issue is automatically closed with a resolution comment.
+
+No additional configuration is required — the workflow uses the existing `PSYNC_PAT_GH` token. Anyone watching this repository will receive a GitHub notification when the issue is opened or commented on.
+
 ---
 
 Once all steps are done, the workflow runs automatically once daily (00:00 UTC) across all projects listed in `PSYNC_PROJECTS`.

--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -27,11 +27,14 @@ jobs:
       PROJECTS: ${{ vars.PSYNC_PROJECTS }}
     steps:
       - name: Sync project reporting metrics across all configured projects
+        id: sync
         run: |
           set -e
 
-          # Clean up JIRA temp files on exit (covers normal completion and errors)
-          trap 'rm -f /tmp/jira_create.json /tmp/jira_issue.json /tmp/jira_resp.json /tmp/jira_wl_list.json /tmp/jira_wl.json' EXIT
+          # Clean up JIRA and error temp files on exit (covers normal completion and errors)
+          WORKFLOW_ERRORS_FILE=/tmp/workflow_errors.txt
+          > "$WORKFLOW_ERRORS_FILE"
+          trap 'rm -f /tmp/jira_create.json /tmp/jira_issue.json /tmp/jira_resp.json /tmp/jira_wl_list.json /tmp/jira_wl.json "$WORKFLOW_ERRORS_FILE"' EXIT
 
           TODAY=$(date -u +%Y-%m-%d)
 
@@ -56,6 +59,12 @@ jobs:
                 printf "%dh\n", int(h1000 / 1000 + 0.5)
               }
             }'
+          }
+
+          # Append an error line to the workflow errors file for end-of-run notification.
+          # $1 = context label (e.g. project:number or item ref), $2 = error message
+          record_error() {
+            printf '[%s] %s\n' "$1" "$2" >> "$WORKFLOW_ERRORS_FILE"
           }
 
           # Extract a field value from a project item JSON blob by field name.
@@ -286,6 +295,9 @@ jobs:
                     }
                   ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
                     -f fieldId="$SYNC_STATUS_FIELD_ID" -f text="$SYNC_STATUS_CODES"
+                fi
+                if echo "$SYNC_STATUS_CODES" | grep -qE 'JIRA_SYNC_ERROR|JIRA_NOT_FOUND|JIRA_CREATE_ERROR'; then
+                  record_error "${PROJECT_OWNER}:${PROJECT_NUMBER} #${ISSUE_NUMBER:-draft}" "$SYNC_STATUS_CODES"
                 fi
                 continue
               fi
@@ -525,6 +537,9 @@ jobs:
                 ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
                   -f fieldId="$SYNC_STATUS_FIELD_ID" -f text="$SYNC_STATUS_CODES"
               fi
+              if echo "$SYNC_STATUS_CODES" | grep -qE 'JIRA_SYNC_ERROR|JIRA_NOT_FOUND|JIRA_CREATE_ERROR'; then
+                record_error "${PROJECT_OWNER}:${PROJECT_NUMBER} #${ISSUE_NUMBER:-draft}" "$SYNC_STATUS_CODES"
+              fi
 
             done
           }
@@ -603,12 +618,14 @@ jobs:
             if [ -n "$GRAPHQL_ERRORS" ]; then
               echo "Error: GraphQL query failed for $PROJECT_OWNER #$PROJECT_NUMBER:"
               echo "$GRAPHQL_ERRORS"
+              record_error "${PROJECT_OWNER}:${PROJECT_NUMBER}" "GraphQL query failed: $GRAPHQL_ERRORS"
               continue
             fi
 
             PROJECT_ID=$(echo "$PAGE_RESPONSE" | jq -r '.data.organization.projectV2.id // ""')
             if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
               echo "Error: Could not resolve project ID for $PROJECT_OWNER #$PROJECT_NUMBER. Check org name and project number. Skipping."
+              record_error "${PROJECT_OWNER}:${PROJECT_NUMBER}" "Could not resolve project ID — check org name and project number"
               continue
             fi
 
@@ -706,6 +723,7 @@ jobs:
               if [ -n "$GRAPHQL_ERRORS" ]; then
                 echo "Error: GraphQL pagination query failed on page $PAGE:"
                 echo "$GRAPHQL_ERRORS"
+                record_error "${PROJECT_OWNER}:${PROJECT_NUMBER}" "GraphQL pagination error on page $PAGE: $GRAPHQL_ERRORS"
                 break
               fi
 
@@ -740,3 +758,54 @@ jobs:
           echo "========================================"
           echo "Total: $TOTAL_UPDATED item(s) updated, $TOTAL_SKIPPED item(s) skipped across all projects."
           echo "========================================"
+
+          # Write error summary to GITHUB_OUTPUT for the notification step
+          if [ -s "$WORKFLOW_ERRORS_FILE" ]; then
+            ERROR_COUNT=$(wc -l < "$WORKFLOW_ERRORS_FILE")
+            echo "has_errors=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "error_summary<<PSYNC_EOF"
+              echo "${ERROR_COUNT} error(s) detected:"
+              cat "$WORKFLOW_ERRORS_FILE"
+              echo "PSYNC_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "has_errors=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update error issue
+        if: always() && steps.sync.outputs.has_errors == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PSYNC_PAT_GH }}
+          ERROR_SUMMARY: ${{ steps.sync.outputs.error_summary }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          printf '%s\n\nWorkflow run: %s\n' "$ERROR_SUMMARY" "$RUN_URL" > /tmp/psync_error_body.txt
+
+          OPEN_ISSUE=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search "bug: Error during project(s) sync workflow run in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$OPEN_ISSUE" ]; then
+            gh issue comment "$OPEN_ISSUE" --repo "${{ github.repository }}" --body-file /tmp/psync_error_body.txt
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "bug: Error during project(s) sync workflow run" \
+              --body-file /tmp/psync_error_body.txt
+          fi
+
+      - name: Close error issue on clean run
+        if: always() && steps.sync.outputs.has_errors == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PSYNC_PAT_GH }}
+        run: |
+          OPEN_ISSUE=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search "bug: Error during project(s) sync workflow run in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$OPEN_ISSUE" ]; then
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue comment "$OPEN_ISSUE" --repo "${{ github.repository }}" \
+              --body "Sync run completed without errors. Closing. Run: $RUN_URL"
+            gh issue close "$OPEN_ISSUE" --repo "${{ github.repository }}"
+          fi


### PR DESCRIPTION
## Summary

- Accumulates error-level events (JIRA_SYNC_ERROR, JIRA_NOT_FOUND, JIRA_CREATE_ERROR, GraphQL failures, unresolvable project IDs) into a temp file during the main step and writes a summary to `GITHUB_OUTPUT`
- **On errors**: opens or comments on issue `bug: Error during project(s) sync workflow run` in this repo using the existing `PSYNC_PAT_GH` token — no duplicate issues, just a new comment if one is already open
- **On clean run**: closes that issue automatically with a resolution comment
- Operator guide updated with section 6 describing the behavior

## No new configuration required

Uses the existing `PSYNC_PAT_GH` token. Anyone watching this repository receives a GitHub notification when the issue is opened or commented on.

Closes #21