### PR TITLE
fix: distinguish JIRA endpoint unreachable from ticket not found on HTTP 404

### DIFF
--- a/.github/workflows/sync-project-reporting-metrics.md
+++ b/.github/workflows/sync-project-reporting-metrics.md
@@ -93,7 +93,8 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 | `NO_VERSION` | `Version` is empty and `Status` is not `Backlog` |
 | `NO_TIME_SPENT` | `Time Spent` is empty and `Status` is `Done` |
 | `NO_ASSIGNEE` | Issue has no assignee and `Status` is `In Progress`, `In Review`, or `Done` |
-| `JIRA_NOT_FOUND` | `External Reference` is set but the JIRA ticket returned HTTP 404 |
+| `JIRA_NOT_FOUND` | `External Reference` is set but the JIRA ticket does not exist (HTTP 404 with JIRA error body) |
+| `JIRA_ENDPOINT_ERROR HTTP_404` | JIRA returned HTTP 404 with no JIRA error body — endpoint unreachable or `PSYNC_JIRA_BASE_URL` misconfigured |
 | `JIRA_SYNC_NOT_ALLOWED` | The JIRA ticket exists but does not carry the `gh-issue-<number>` label |
 | `JIRA_SYNC_ERROR HTTP_<code>` | A JIRA API call failed with the given HTTP status code |
 | `JIRA_CREATE_ERROR HTTP_<code>` | A `CREATE` directive was detected but the JIRA ticket creation failed |
@@ -175,6 +176,14 @@ When this condition passes, the workflow will:
 
 If `PSYNC_PAT_JIRA` is not set, the JIRA sync step is skipped silently.
 
+### 6. Error notifications via GitHub issues
+
+When errors occur during a run (JIRA sync failures, GraphQL errors, unresolvable project IDs), the workflow automatically opens a GitHub issue in this repository titled **`bug: Error during project(s) sync workflow run`**. If an issue with that title is already open, a new comment is added instead of opening a duplicate.
+
+When a subsequent run completes without errors, the open issue is automatically closed with a resolution comment.
+
+No additional configuration is required — the workflow uses the existing `PSYNC_PAT_GH` token. Anyone watching this repository will receive a GitHub notification when the issue is opened or commented on.
+
 ---
 
 Once all steps are done, the workflow runs automatically once daily (00:00 UTC) across all projects listed in `PSYNC_PROJECTS`.
@@ -242,7 +251,8 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **`Alerts` shows `NO_PRIORITY`** → set the `Priority` field on the project item, or move it back to `Backlog` if prioritization is not yet applicable
 - **`Alerts` shows `NO_TIME_SPENT`** → the item is `Done` but `Time Spent` is empty; log the actual time spent
 - **`Alerts` shows `NO_ASSIGNEE`** → the item is `In Progress`, `In Review`, or `Done` but has no assignee; assign it to the responsible person
-- **`Alerts` shows `JIRA_NOT_FOUND`** → the ticket ID in `External Reference` does not exist or is not accessible with the provided credentials
+- **`Alerts` shows `JIRA_NOT_FOUND`** → the ticket ID in `External Reference` does not exist in JIRA; verify the key is correct
+- **`Alerts` shows `JIRA_ENDPOINT_ERROR HTTP_404`** → JIRA returned a 404 with no JIRA error payload; the endpoint is likely unreachable or `PSYNC_JIRA_BASE_URL` is misconfigured — verify the URL and network connectivity
 - **`Alerts` shows `JIRA_SYNC_NOT_ALLOWED`** → the JIRA ticket exists but lacks the `gh-issue-<number>` label; add it (e.g. `gh-issue-3`) to the JIRA ticket to opt it in to syncing
 - **`Alerts` shows `JIRA_SYNC_ERROR HTTP_<code>`** → a JIRA API call failed; check the Actions log for the response body and consult the JIRA troubleshooting entries below
 - **`Alerts` shows `CHILDREN_STATUS`** → resolve the status inconsistency: if the parent is `Done`, all children must also be `Done`; if the parent is active (not `Backlog`/`Next`), no child should still be in `Backlog`

--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -27,11 +27,14 @@ jobs:
       PROJECTS: ${{ vars.PSYNC_PROJECTS }}
     steps:
       - name: Sync project reporting metrics across all configured projects
+        id: sync
         run: |
           set -e
 
-          # Clean up JIRA temp files on exit (covers normal completion and errors)
-          trap 'rm -f /tmp/jira_create.json /tmp/jira_issue.json /tmp/jira_resp.json /tmp/jira_wl_list.json /tmp/jira_wl.json' EXIT
+          # Clean up JIRA and error temp files on exit (covers normal completion and errors)
+          WORKFLOW_ERRORS_FILE=/tmp/workflow_errors.txt
+          > "$WORKFLOW_ERRORS_FILE"
+          trap 'rm -f /tmp/jira_create.json /tmp/jira_issue.json /tmp/jira_resp.json /tmp/jira_wl_list.json /tmp/jira_wl.json "$WORKFLOW_ERRORS_FILE"' EXIT
 
           TODAY=$(date -u +%Y-%m-%d)
 
@@ -56,6 +59,12 @@ jobs:
                 printf "%dh\n", int(h1000 / 1000 + 0.5)
               }
             }'
+          }
+
+          # Append an error line to the workflow errors file for end-of-run notification.
+          # $1 = context label (e.g. project:number or item ref), $2 = error message
+          record_error() {
+            printf '[%s] %s\n' "$1" "$2" >> "$WORKFLOW_ERRORS_FILE"
           }
 
           # Extract a field value from a project item JSON blob by field name.
@@ -287,6 +296,9 @@ jobs:
                   ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
                     -f fieldId="$SYNC_STATUS_FIELD_ID" -f text="$SYNC_STATUS_CODES"
                 fi
+                if echo "$SYNC_STATUS_CODES" | grep -qE 'JIRA_SYNC_ERROR|JIRA_NOT_FOUND|JIRA_CREATE_ERROR|JIRA_ENDPOINT_ERROR'; then
+                  record_error "${PROJECT_OWNER}:${PROJECT_NUMBER} #${ISSUE_NUMBER:-draft}" "$SYNC_STATUS_CODES"
+                fi
                 continue
               fi
 
@@ -340,8 +352,17 @@ jobs:
                 JIRA_GET_STATUS="${JIRA_GET_STATUS:-000}"
 
                 if [ "$JIRA_GET_STATUS" -eq 404 ]; then
-                  echo "  → Warning: JIRA issue $EXTERNAL_REF not found (HTTP 404). Skipping JIRA sync."
-                  SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }JIRA_NOT_FOUND"
+                  # Distinguish "ticket not found" (JIRA returns JSON with errorMessages)
+                  # from an unreachable/misconfigured endpoint (proxy 404 with no JIRA body).
+                  JIRA_ERR_MSG=$(jq -r '.errorMessages[0] // empty' /tmp/jira_issue.json 2>/dev/null)
+                  if [ -n "$JIRA_ERR_MSG" ]; then
+                    echo "  → Warning: JIRA issue $EXTERNAL_REF not found (HTTP 404). Skipping JIRA sync."
+                    SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }JIRA_NOT_FOUND"
+                  else
+                    echo "  → Warning: JIRA endpoint returned HTTP 404 with no JIRA error body — endpoint may be unreachable or PSYNC_JIRA_BASE_URL is misconfigured. Skipping JIRA sync."
+                    echo "  → JIRA error response:" && cat /tmp/jira_issue.json
+                    SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }JIRA_ENDPOINT_ERROR HTTP_404"
+                  fi
                 elif [ "$JIRA_GET_STATUS" -lt 200 ] || [ "$JIRA_GET_STATUS" -ge 300 ]; then
                   echo "  → Warning: Failed to fetch JIRA issue $EXTERNAL_REF (HTTP $JIRA_GET_STATUS). Skipping JIRA sync."
                   echo "  → JIRA error response:" && cat /tmp/jira_issue.json
@@ -525,6 +546,9 @@ jobs:
                 ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
                   -f fieldId="$SYNC_STATUS_FIELD_ID" -f text="$SYNC_STATUS_CODES"
               fi
+              if echo "$SYNC_STATUS_CODES" | grep -qE 'JIRA_SYNC_ERROR|JIRA_NOT_FOUND|JIRA_CREATE_ERROR|JIRA_ENDPOINT_ERROR'; then
+                record_error "${PROJECT_OWNER}:${PROJECT_NUMBER} #${ISSUE_NUMBER:-draft}" "$SYNC_STATUS_CODES"
+              fi
 
             done
           }
@@ -603,12 +627,14 @@ jobs:
             if [ -n "$GRAPHQL_ERRORS" ]; then
               echo "Error: GraphQL query failed for $PROJECT_OWNER #$PROJECT_NUMBER:"
               echo "$GRAPHQL_ERRORS"
+              record_error "${PROJECT_OWNER}:${PROJECT_NUMBER}" "GraphQL query failed: $GRAPHQL_ERRORS"
               continue
             fi
 
             PROJECT_ID=$(echo "$PAGE_RESPONSE" | jq -r '.data.organization.projectV2.id // ""')
             if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
               echo "Error: Could not resolve project ID for $PROJECT_OWNER #$PROJECT_NUMBER. Check org name and project number. Skipping."
+              record_error "${PROJECT_OWNER}:${PROJECT_NUMBER}" "Could not resolve project ID — check org name and project number"
               continue
             fi
 
@@ -706,6 +732,7 @@ jobs:
               if [ -n "$GRAPHQL_ERRORS" ]; then
                 echo "Error: GraphQL pagination query failed on page $PAGE:"
                 echo "$GRAPHQL_ERRORS"
+                record_error "${PROJECT_OWNER}:${PROJECT_NUMBER}" "GraphQL pagination error on page $PAGE: $GRAPHQL_ERRORS"
                 break
               fi
 
@@ -740,3 +767,54 @@ jobs:
           echo "========================================"
           echo "Total: $TOTAL_UPDATED item(s) updated, $TOTAL_SKIPPED item(s) skipped across all projects."
           echo "========================================"
+
+          # Write error summary to GITHUB_OUTPUT for the notification step
+          if [ -s "$WORKFLOW_ERRORS_FILE" ]; then
+            ERROR_COUNT=$(wc -l < "$WORKFLOW_ERRORS_FILE")
+            echo "has_errors=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "error_summary<<PSYNC_EOF"
+              echo "${ERROR_COUNT} error(s) detected:"
+              cat "$WORKFLOW_ERRORS_FILE"
+              echo "PSYNC_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "has_errors=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update error issue
+        if: always() && steps.sync.outputs.has_errors == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PSYNC_PAT_GH }}
+          ERROR_SUMMARY: ${{ steps.sync.outputs.error_summary }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          printf '%s\n\nWorkflow run: %s\n' "$ERROR_SUMMARY" "$RUN_URL" > /tmp/psync_error_body.txt
+
+          OPEN_ISSUE=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search "bug: Error during project(s) sync workflow run in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$OPEN_ISSUE" ]; then
+            gh issue comment "$OPEN_ISSUE" --repo "${{ github.repository }}" --body-file /tmp/psync_error_body.txt
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "bug: Error during project(s) sync workflow run" \
+              --body-file /tmp/psync_error_body.txt
+          fi
+
+      - name: Close error issue on clean run
+        if: always() && steps.sync.outputs.has_errors == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PSYNC_PAT_GH }}
+        run: |
+          OPEN_ISSUE=$(gh issue list --repo "${{ github.repository }}" --state open \
+            --search "bug: Error during project(s) sync workflow run in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$OPEN_ISSUE" ]; then
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue comment "$OPEN_ISSUE" --repo "${{ github.repository }}" \
+              --body "Sync run completed without errors. Closing. Run: $RUN_URL"
+            gh issue close "$OPEN_ISSUE" --repo "${{ github.repository }}"
+          fi


### PR DESCRIPTION
## Summary

When JIRA returns HTTP 404, the workflow now checks whether the response body contains `errorMessages` (JIRA's own error format):
- **Has JIRA error body** → `JIRA_NOT_FOUND` (ticket does not exist)
- **No JIRA error body** → `JIRA_ENDPOINT_ERROR HTTP_404` (endpoint unreachable or `PSYNC_JIRA_BASE_URL` misconfigured)

Both codes trigger the error notification issue. Operator guide updated with the new alert code and troubleshooting entry.