### PR TITLE
fix: Support Pull Request assignees in NO_ASSIGNEE validation

### DIFF
--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -606,7 +606,21 @@ jobs:
                       nodes {
                         id
                         isArchived
-                        content { ... on Issue { number title url assignees(first: 5) { nodes { login } } subIssues(first: 50) { nodes { number } } } }
+                        content {
+                          ... on Issue {
+                            number
+                            title
+                            url
+                            assignees(first: 5) { nodes { login } }
+                            subIssues(first: 50) { nodes { number } }
+                          }
+                          ... on PullRequest {
+                            number
+                            title
+                            url
+                            assignees(first: 5) { nodes { login } }
+                          }
+                        }
                         fieldValues(first: 20) {
                           nodes {
                             ... on ProjectV2ItemFieldTextValue {
@@ -712,7 +726,21 @@ jobs:
                         nodes {
                           id
                           isArchived
-                          content { ... on Issue { number title url assignees(first: 5) { nodes { login } } subIssues(first: 50) { nodes { number } } } }
+                          content {
+                            ... on Issue {
+                              number
+                              title
+                              url
+                              assignees(first: 5) { nodes { login } }
+                              subIssues(first: 50) { nodes { number } }
+                            }
+                            ... on PullRequest {
+                              number
+                              title
+                              url
+                              assignees(first: 5) { nodes { login } }
+                            }
+                          }
                           fieldValues(first: 20) {
                             nodes {
                               ... on ProjectV2ItemFieldTextValue {


### PR DESCRIPTION
## Description

This PR fixes the issue where the `NO_ASSIGNEE` alert is incorrectly triggered for Pull Requests that have assignees when added to GitHub Projects.

## Changes

- Added `PullRequest` fragment to GraphQL queries at lines 609 and 715
- Now queries assignees for both Issues and Pull Requests
- Pull Requests with assignees will no longer trigger false positive `NO_ASSIGNEE` alerts

## Technical Details

The workflow's GraphQL queries previously only included the `Issue` content type:

```graphql
content { ... on Issue { number title url assignees(first: 5) { nodes { login } } subIssues(first: 50) { nodes { number } } } }
```

This caused the `assignees` field to return empty for Pull Requests, triggering the `NO_ASSIGNEE` alert at line 245 even when PRs had assignees.

The fix adds a `PullRequest` fragment to both the initial query and pagination query:

```graphql
content {
  ... on Issue {
    number
    title
    url
    assignees(first: 5) { nodes { login } }
    subIssues(first: 50) { nodes { number } }
  }
  ... on PullRequest {
    number
    title
    url
    assignees(first: 5) { nodes { login } }
  }
}
```

Note: Pull Requests don't have `subIssues`, so the `CHILDREN_STATUS` validation will only apply to Issues (which is the correct behavior).

## Testing

Tested with PR https://github.com/apache/incubator-kie-tools/pull/2554 which previously showed the false positive alert.

Fixes #28