### PR TITLE
feat: Add export workflow for Done items to CSV

### DIFF
--- a/.github/workflows/export-done-items.md
+++ b/.github/workflows/export-done-items.md
@@ -1,0 +1,271 @@
+# Export Done Items Workflow
+
+Automatically exports completed items from GitHub Projects to CSV files in the repository. Runs weekly and creates incremental exports with one CSV file per project.
+
+## Overview
+
+This workflow:
+- Runs every Sunday at midnight UTC (00:00)
+- Exports items with Status = "Done" from all configured projects
+- Creates date-stamped CSV files in the `exports/` directory
+- Only exports items without validation alerts
+- Performs incremental exports (only new Done items since last export)
+- On first run, exports all historical Done items
+
+## Schedule
+
+```yaml
+schedule:
+  - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
+```
+
+**Manual trigger:** Available via workflow_dispatch
+
+## Configuration
+
+### Required Secrets
+
+- `PSYNC_PAT_GH`: Personal Access Token with `project` and `read:org` scopes
+  - Same token used by the sync workflow
+  - Must have write access to the repository (for committing CSV files)
+
+### Required Variables
+
+- `PSYNC_PROJECTS`: Space-separated list of projects in format `owner:number`
+  - Example: `kubesmarts:1 kubesmarts:2 another-org:5`
+  - Same variable used by the sync workflow
+
+## Export Criteria
+
+An item is exported **only if ALL** conditions are met:
+
+1. ✅ **Status = "Done"** (case-insensitive)
+2. ✅ **Has GitHub issue number** (not a draft item)
+3. ✅ **Not archived**
+4. ✅ **Reporting Date > last export date** (or first run)
+5. ✅ **Alerts field is empty** (no validation issues)
+
+Items with alerts are skipped and will be exported once the alerts are resolved.
+
+## File Structure
+
+```
+exports/
+├── kubesmarts-1/
+│   ├── done-items-2026-03-16.csv
+│   ├── done-items-2026-03-23.csv
+│   └── done-items-2026-03-30.csv
+├── kubesmarts-2/
+│   └── done-items-2026-03-30.csv
+└── another-org-5/
+    └── done-items-2026-03-25.csv
+```
+
+- One directory per project: `exports/<owner>-<number>/`
+- Date-stamped CSV files: `done-items-YYYY-MM-DD.csv`
+- Files are committed and pushed to the repository
+
+## CSV Format
+
+### Header (fixed for all projects)
+
+```csv
+Issue Number,Title,Assignees,Type,Area,Priority,Initiative,Version,Size,Estimate,Time Spent,Reporting Date,External Reference,Comments
+```
+
+### Field Descriptions
+
+| Field | Description | Notes |
+|-------|-------------|-------|
+| Issue Number | GitHub issue number | Required (draft items skipped) |
+| Title | Issue title | Escaped for CSV |
+| Assignees | Comma-separated list of assignees | Empty if no assignees |
+| Type | Issue type (Story, Bug, Task, etc.) | Empty if field not in project |
+| Area | Area field value | Empty if field not in project |
+| Priority | Priority field value | Empty if field not in project |
+| Initiative | Initiative field value | Empty if field not in project |
+| Version | Version field value | Empty if field not in project |
+| Size | Size field value (S, M, L, etc.) | Empty if field not in project |
+| Estimate | Estimate in weeks | Empty if field not in project |
+| Time Spent | Time spent in weeks | Empty if field not in project |
+| Reporting Date | Date when item was last updated | From project field |
+| External Reference | JIRA ticket key or other reference | Empty if field not in project |
+| Comments | First 200 characters of issue body | Escaped for CSV |
+
+### CSV Escaping
+
+- Fields containing commas, quotes, or newlines are wrapped in double quotes
+- Double quotes within fields are escaped as `""`
+- Multiple assignees are comma-separated within quotes: `"alice,bob,charlie"`
+
+## Export Logic
+
+### First Run (No Previous Export)
+
+When no CSV files exist for a project:
+- Exports **ALL** items with Status = "Done" and no Alerts
+- Creates baseline export with all historical completed items
+- File: `exports/<project>/done-items-YYYY-MM-DD.csv`
+
+### Subsequent Runs (Incremental)
+
+When previous CSV file(s) exist:
+- Finds most recent CSV file by date in filename
+- Extracts last export date (e.g., `2026-03-23`)
+- Exports only items where Reporting Date > last export date
+- Skips items with Alerts (exported when alerts are fixed)
+- File: `exports/<project>/done-items-YYYY-MM-DD.csv`
+
+### No New Items
+
+If no items meet the export criteria:
+- No CSV file is created
+- Workflow completes successfully
+- No commit is made
+
+## Workflow Output
+
+### Example: First Run
+
+```
+========================================
+Project: kubesmarts #1
+========================================
+First export for kubesmarts:1 - exporting all Done items
+Fetching project metadata and page 1...
+Project ID: PVT_kwDOABcD...
+
+  → Skipping issue #58: has alerts (NO_TIME_SPENT)
+
+✓ Exported 42 item(s) to exports/kubesmarts-1/done-items-2026-03-30.csv
+  Skipped 1 item(s) with alerts
+
+========================================
+Total: 42 item(s) exported across all projects
+========================================
+```
+
+### Example: Incremental Run
+
+```
+========================================
+Project: kubesmarts #1
+========================================
+Incremental export since 2026-03-23
+Fetching project metadata and page 1...
+Project ID: PVT_kwDOABcD...
+
+✓ Exported 5 item(s) to exports/kubesmarts-1/done-items-2026-03-30.csv
+  Skipped 12 item(s) already exported
+
+========================================
+Total: 5 item(s) exported across all projects
+========================================
+```
+
+## Commit Message
+
+When exports are created, the workflow commits with:
+
+```
+Export Done items YYYY-MM-DD
+```
+
+Example: `Export Done items 2026-03-30`
+
+## Troubleshooting
+
+### No CSV files created
+
+**Possible causes:**
+- No items with Status = "Done"
+- All Done items have Alerts
+- All Done items already exported (Reporting Date ≤ last export date)
+- All Done items are draft items (no GitHub issue number)
+
+**Solution:** Check the workflow log for skip reasons
+
+### GraphQL errors
+
+**Possible causes:**
+- Invalid project owner or number in `PSYNC_PROJECTS`
+- PAT lacks required permissions
+- Project doesn't exist or is not accessible
+
+**Solution:** Verify `PSYNC_PROJECTS` variable and PAT permissions
+
+### Missing fields in CSV
+
+**Expected behavior:** If a project doesn't have a field (e.g., "Initiative", "Size"), the CSV will have an empty value for that field. This is normal and allows the same CSV format across all projects.
+
+### Items with alerts not exported
+
+**Expected behavior:** Items with validation alerts are intentionally skipped. They will be exported once the alerts are resolved and the Reporting Date is updated.
+
+## Integration with Sync Workflow
+
+This workflow complements the [Sync Project Reporting Metrics](.github/workflows/sync-project-reporting-metrics.md) workflow:
+
+- **Sync workflow** (daily): Updates project fields, validates data, syncs to JIRA
+- **Export workflow** (weekly): Exports clean, validated Done items to CSV
+
+Both workflows:
+- Use the same `PSYNC_PROJECTS` variable
+- Use the same `PSYNC_PAT_GH` secret
+- Query the same projects
+- Use the same field extraction logic
+
+## Use Cases
+
+- **Historical reporting**: Track completed work over time
+- **Velocity analysis**: Analyze estimate vs. actual time spent
+- **External tools**: Import CSV data into spreadsheets or BI tools
+- **Retrospectives**: Review completed items from previous sprints
+- **Audit trail**: Version-controlled record of completed work
+
+## Maintenance
+
+### Adding a new project
+
+1. Add project to `PSYNC_PROJECTS` variable (format: `owner:number`)
+2. Next Sunday, workflow will create first export with all Done items
+3. Subsequent runs will be incremental
+
+### Removing a project
+
+1. Remove project from `PSYNC_PROJECTS` variable
+2. Existing CSV files in `exports/<project>/` remain in repository
+3. No new exports will be created for that project
+
+### Changing export schedule
+
+Edit the cron expression in the workflow file:
+
+```yaml
+schedule:
+  - cron: '0 0 * * 0'  # Current: Every Sunday at 00:00 UTC
+```
+
+Examples:
+- Daily: `0 0 * * *`
+- Every Monday: `0 0 * * 1`
+- First day of month: `0 0 1 * *`
+
+## Testing
+
+### Manual trigger
+
+1. Go to Actions tab in GitHub
+2. Select "Export Done Items" workflow
+3. Click "Run workflow"
+4. Select branch and click "Run workflow"
+
+### Verify exports
+
+1. Check `exports/<project>/` directories for new CSV files
+2. Open CSV files to verify data
+3. Check git history for commit message
+
+### Test with specific project
+
+Temporarily modify `PSYNC_PROJECTS` variable to include only one project for testing.

--- a/.github/workflows/export-done-items.yml
+++ b/.github/workflows/export-done-items.yml
@@ -1,0 +1,358 @@
+name: Export Done Items
+
+# ---------------------------------------------------------------------------
+# Schedule configuration
+# Runs every Sunday at 00:00 UTC (midnight Saturday/Sunday)
+# ---------------------------------------------------------------------------
+on:
+  schedule:
+    - cron: '0 0 * * 0'   # Every Sunday at 00:00 UTC
+  workflow_dispatch:
+
+# Requires a PAT with 'project' and 'read:org' scopes stored as secret PSYNC_PAT_GH.
+# Uses the same PSYNC_PROJECTS variable as the sync workflow.
+
+jobs:
+  export-done-items:
+    name: Export done items to CSV
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.PSYNC_PAT_GH }}
+      PROJECTS: ${{ vars.PSYNC_PROJECTS }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Export done items for all projects
+        id: export
+        run: |
+          set -e
+
+          TODAY=$(date -u +%Y-%m-%d)
+          EXPORT_BASE_DIR="exports"
+
+          # Extract a field value from a project item JSON blob by field name.
+          # Handles text, number, single-select and date field types.
+          get_field() {
+            local item_json="$1"
+            local field_name="$2"
+            echo "$item_json" | jq -r --arg n "$field_name" '
+              [ .fieldValues.nodes[] | select(.field.name == $n) ] |
+              if length == 0 then ""
+              else .[0] |
+                if .text != null then .text
+                elif .number != null then (.number | tostring)
+                elif .["name"] != null then .["name"]
+                elif .date != null then .date
+                else ""
+                end
+              end
+            '
+          }
+
+          # Escape CSV field value (handle quotes and commas)
+          escape_csv() {
+            local value="$1"
+            # Replace " with ""
+            value="${value//\"/\"\"}"
+            # If contains comma, newline, or quote, wrap in quotes
+            if [[ "$value" =~ [,\"$'\n'] ]]; then
+              echo "\"$value\""
+            else
+              echo "$value"
+            fi
+          }
+
+          # ---------------------------------------------------------------------------
+          # Iterate over all configured projects
+          # ---------------------------------------------------------------------------
+          TOTAL_EXPORTED=0
+
+          for PROJECT_ENTRY in $PROJECTS; do
+            PROJECT_OWNER="${PROJECT_ENTRY%%:*}"
+            PROJECT_NUMBER="${PROJECT_ENTRY##*:}"
+
+            echo ""
+            echo "========================================"
+            echo "Project: $PROJECT_OWNER #$PROJECT_NUMBER"
+            echo "========================================"
+
+            # Create export directory for this project
+            PROJECT_EXPORT_DIR="${EXPORT_BASE_DIR}/${PROJECT_OWNER}-${PROJECT_NUMBER}"
+            mkdir -p "$PROJECT_EXPORT_DIR"
+
+            # Find last export date from most recent CSV file
+            LAST_EXPORT_FILE=$(ls -1 "$PROJECT_EXPORT_DIR"/done-items-*.csv 2>/dev/null | tail -1)
+            
+            if [ -z "$LAST_EXPORT_FILE" ]; then
+              echo "First export for ${PROJECT_OWNER}:${PROJECT_NUMBER} - exporting all Done items"
+              LAST_EXPORT_DATE="1970-01-01"
+            else
+              LAST_EXPORT_DATE=$(echo "$LAST_EXPORT_FILE" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+              echo "Incremental export since ${LAST_EXPORT_DATE}"
+            fi
+
+            # Fetch project metadata and first page of items
+            echo "Fetching project metadata and page 1..."
+            PAGE_RESPONSE=$(gh api graphql -f query='
+              query($owner: String!, $number: Int!) {
+                organization(login: $owner) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 30) {
+                      nodes {
+                        ... on ProjectV2Field {
+                          id
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                        }
+                      }
+                    }
+                    items(first: 100) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        isArchived
+                        content {
+                          ... on Issue {
+                            number
+                            title
+                            url
+                            body
+                            assignees(first: 10) { nodes { login } }
+                          }
+                        }
+                        fieldValues(first: 30) {
+                          nodes {
+                            ... on ProjectV2ItemFieldTextValue {
+                              text
+                              field { ... on ProjectV2Field { name } }
+                            }
+                            ... on ProjectV2ItemFieldNumberValue {
+                              number
+                              field { ... on ProjectV2Field { name } }
+                            }
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              name
+                              field { ... on ProjectV2SingleSelectField { name } }
+                            }
+                            ... on ProjectV2ItemFieldDateValue {
+                              date
+                              field { ... on ProjectV2Field { name } }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ' -f owner="$PROJECT_OWNER" -F number=$PROJECT_NUMBER)
+
+            # Check for GraphQL errors
+            GRAPHQL_ERRORS=$(echo "$PAGE_RESPONSE" | jq -r '.errors // empty')
+            if [ -n "$GRAPHQL_ERRORS" ]; then
+              echo "Error: GraphQL query failed for $PROJECT_OWNER #$PROJECT_NUMBER:"
+              echo "$GRAPHQL_ERRORS"
+              continue
+            fi
+
+            PROJECT_ID=$(echo "$PAGE_RESPONSE" | jq -r '.data.organization.projectV2.id // ""')
+            if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
+              echo "Error: Could not resolve project ID. Skipping."
+              continue
+            fi
+
+            echo "Project ID: $PROJECT_ID"
+
+            # Collect all items across all pages
+            ITEMS_FILE=$(mktemp)
+            echo "$PAGE_RESPONSE" | jq -c '.data.organization.projectV2.items.nodes[]' >> "$ITEMS_FILE"
+
+            # Paginate through remaining pages
+            HAS_NEXT=$(echo "$PAGE_RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+            CURSOR=$(echo "$PAGE_RESPONSE"   | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+            PAGE=1
+
+            while [ "$HAS_NEXT" = "true" ]; do
+              PAGE=$((PAGE + 1))
+              echo "Fetching page $PAGE..."
+
+              PAGE_RESPONSE=$(gh api graphql -f query='
+                query($owner: String!, $number: Int!, $cursor: String!) {
+                  organization(login: $owner) {
+                    projectV2(number: $number) {
+                      items(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          id
+                          isArchived
+                          content {
+                            ... on Issue {
+                              number
+                              title
+                              url
+                              body
+                              assignees(first: 10) { nodes { login } }
+                            }
+                          }
+                          fieldValues(first: 30) {
+                            nodes {
+                              ... on ProjectV2ItemFieldTextValue {
+                                text
+                                field { ... on ProjectV2Field { name } }
+                              }
+                              ... on ProjectV2ItemFieldNumberValue {
+                                number
+                                field { ... on ProjectV2Field { name } }
+                              }
+                              ... on ProjectV2ItemFieldSingleSelectValue {
+                                name
+                                field { ... on ProjectV2SingleSelectField { name } }
+                              }
+                              ... on ProjectV2ItemFieldDateValue {
+                                date
+                                field { ... on ProjectV2Field { name } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ' -f owner="$PROJECT_OWNER" -F number=$PROJECT_NUMBER -f cursor="$CURSOR")
+
+              GRAPHQL_ERRORS=$(echo "$PAGE_RESPONSE" | jq -r '.errors // empty')
+              if [ -n "$GRAPHQL_ERRORS" ]; then
+                echo "Error: GraphQL pagination failed on page $PAGE"
+                break
+              fi
+
+              echo "$PAGE_RESPONSE" | jq -c '.data.organization.projectV2.items.nodes[]' >> "$ITEMS_FILE"
+
+              HAS_NEXT=$(echo "$PAGE_RESPONSE" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+              CURSOR=$(echo "$PAGE_RESPONSE"   | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+            done
+
+            # Create CSV file for this export
+            EXPORT_FILE="${PROJECT_EXPORT_DIR}/done-items-${TODAY}.csv"
+            
+            # Write CSV header
+            echo "Issue Number,Title,Assignees,Type,Area,Priority,Initiative,Version,Size,Estimate,Time Spent,Reporting Date,External Reference,Comments" > "$EXPORT_FILE"
+
+            # Process items and export Done items
+            EXPORTED_COUNT=0
+            SKIPPED_ALERTS=0
+            SKIPPED_DATE=0
+
+            while IFS= read -r item; do
+              IS_ARCHIVED=$(echo "$item" | jq -r '.isArchived')
+              ISSUE_NUMBER=$(echo "$item" | jq -r '.content.number // ""')
+              
+              # Skip archived items and draft items (no issue number)
+              [ "$IS_ARCHIVED" = "true" ] && continue
+              [ -z "$ISSUE_NUMBER" ] && continue
+
+              # Get status and check if Done
+              STATUS=$(get_field "$item" "Status")
+              STATUS_LC=$(echo "$STATUS" | tr '[:upper:]' '[:lower:]')
+              
+              [ "$STATUS_LC" != "done" ] && continue
+
+              # Get Reporting Date and check if after last export
+              REPORTING_DATE=$(get_field "$item" "Reporting Date")
+              
+              if [ -n "$REPORTING_DATE" ] && [ "$REPORTING_DATE" \< "$LAST_EXPORT_DATE" ]; then
+                SKIPPED_DATE=$((SKIPPED_DATE + 1))
+                continue
+              fi
+
+              # Check for alerts - skip if any exist
+              ALERTS=$(get_field "$item" "Alerts")
+              if [ -n "$ALERTS" ]; then
+                echo "  → Skipping issue #${ISSUE_NUMBER}: has alerts (${ALERTS})"
+                SKIPPED_ALERTS=$((SKIPPED_ALERTS + 1))
+                continue
+              fi
+
+              # Extract all fields
+              TITLE=$(echo "$item" | jq -r '.content.title // ""')
+              ASSIGNEES=$(echo "$item" | jq -r '[.content.assignees.nodes[].login] | join(",")' 2>/dev/null || echo "")
+              TYPE=$(get_field "$item" "Type")
+              AREA=$(get_field "$item" "Area")
+              PRIORITY=$(get_field "$item" "Priority")
+              INITIATIVE=$(get_field "$item" "Initiative")
+              VERSION=$(get_field "$item" "Version")
+              SIZE=$(get_field "$item" "Size")
+              ESTIMATE=$(get_field "$item" "Estimate")
+              TIME_SPENT=$(get_field "$item" "Time Spent")
+              EXTERNAL_REF=$(get_field "$item" "External Reference")
+              COMMENTS=$(echo "$item" | jq -r '.content.body // ""' | head -c 200)
+
+              # Build CSV line with proper escaping
+              CSV_LINE="${ISSUE_NUMBER},"
+              CSV_LINE+="$(escape_csv "$TITLE"),"
+              CSV_LINE+="$(escape_csv "$ASSIGNEES"),"
+              CSV_LINE+="$(escape_csv "$TYPE"),"
+              CSV_LINE+="$(escape_csv "$AREA"),"
+              CSV_LINE+="$(escape_csv "$PRIORITY"),"
+              CSV_LINE+="$(escape_csv "$INITIATIVE"),"
+              CSV_LINE+="$(escape_csv "$VERSION"),"
+              CSV_LINE+="$(escape_csv "$SIZE"),"
+              CSV_LINE+="$(escape_csv "$ESTIMATE"),"
+              CSV_LINE+="$(escape_csv "$TIME_SPENT"),"
+              CSV_LINE+="$(escape_csv "$REPORTING_DATE"),"
+              CSV_LINE+="$(escape_csv "$EXTERNAL_REF"),"
+              CSV_LINE+="$(escape_csv "$COMMENTS")"
+
+              echo "$CSV_LINE" >> "$EXPORT_FILE"
+              EXPORTED_COUNT=$((EXPORTED_COUNT + 1))
+
+            done < "$ITEMS_FILE"
+
+            rm -f "$ITEMS_FILE"
+
+            echo ""
+            if [ $EXPORTED_COUNT -gt 0 ]; then
+              echo "✓ Exported $EXPORTED_COUNT item(s) to ${EXPORT_FILE}"
+              TOTAL_EXPORTED=$((TOTAL_EXPORTED + EXPORTED_COUNT))
+            else
+              echo "No new Done items to export"
+              rm -f "$EXPORT_FILE"  # Remove empty CSV file
+            fi
+            
+            if [ $SKIPPED_ALERTS -gt 0 ]; then
+              echo "  Skipped $SKIPPED_ALERTS item(s) with alerts"
+            fi
+            if [ $SKIPPED_DATE -gt 0 ]; then
+              echo "  Skipped $SKIPPED_DATE item(s) already exported"
+            fi
+
+          done
+
+          echo ""
+          echo "========================================"
+          echo "Total: $TOTAL_EXPORTED item(s) exported across all projects"
+          echo "========================================"
+
+          # Set output for commit step
+          if [ $TOTAL_EXPORTED -gt 0 ]; then
+            echo "has_exports=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_exports=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push exports
+        if: steps.export.outputs.has_exports == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add exports/
+          git commit -m "Export Done items $(date -u +%Y-%m-%d)"
+          git push
+
+# Made with Bob

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A collection of project management automations for GitHub Projects, covering pro
 | Workflow | Description |
 |----------|-------------|
 | [Sync Project Reporting Metrics](.github/workflows/sync-project-reporting-metrics.md) | Tracks field changes across multiple GitHub Projects, maintains a reporting log, and optionally syncs progress to JIRA |
+| [Export Done Items](.github/workflows/export-done-items.md) | Exports completed items from GitHub Projects to CSV files with incremental weekly exports |
 
 ## User guides
 


### PR DESCRIPTION
## Description

Implements a new workflow that exports completed items from GitHub Projects to CSV files in the repository.

## Changes

- New workflow `.github/workflows/export-done-items.yml`
  - Runs every Sunday at 00:00 UTC
  - Exports Done items to `exports/<project>/done-items-YYYY-MM-DD.csv`
  - Incremental exports (only new items since last export)
  - Skips items with validation alerts
  
- Comprehensive documentation in `.github/workflows/export-done-items.md`
- Updated README.md with new automation entry

## Configuration

Uses existing `PSYNC_PROJECTS` variable and `PSYNC_PAT_GH` secret.

## Benefits

✅ Historical record of completed work  
✅ One CSV per project per week  
✅ Quality assurance (skips items with alerts)  
✅ Version controlled exports  

Closes #35