### PR TITLE
Add contributor whitelist filtering to sync and export workflows

### DIFF
--- a/.github/workflows/export-done-items.md
+++ b/.github/workflows/export-done-items.md
@@ -13,6 +13,21 @@ This workflow:
 - New items are prepended at the beginning, sorted by Reporting Date (descending)
 - On first run, exports all historical Done items
 
+### Contributor Whitelist Filtering
+
+The workflow can be configured to export only items assigned to approved contributors. This is controlled by a `contributors.csv` file in the repository root.
+
+**When `contributors.csv` exists:**
+- Only items with at least one whitelisted assignee are exported
+- Items with no assignees or only non-whitelisted assignees are skipped
+- Skipped items are logged with reason "assignees not in contributor whitelist"
+
+**When `contributors.csv` doesn't exist:**
+- All items are exported (backward compatible behavior)
+
+See the [Contributor Access Management](../docs/user-guide-rms-projects.md#contributor-access-management) section in the user guide for details on managing the whitelist.
+
+
 ## Schedule
 
 ```yaml
@@ -45,8 +60,11 @@ An item is exported **only if ALL** conditions are met:
 3. ✅ **Not archived**
 4. ✅ **Reporting Date > last export date** (or first run)
 5. ✅ **Alerts field is empty** (no validation issues)
+6. ✅ **Assignee is in contributor whitelist** (if `contributors.csv` exists)
 
 Items with alerts are skipped and will be exported once the alerts are resolved.
+
+Items with non-whitelisted assignees (when whitelist is active) are skipped and logged.
 
 ## File Structure
 

--- a/.github/workflows/export-done-items.yml
+++ b/.github/workflows/export-done-items.yml
@@ -69,6 +69,69 @@ jobs:
             fi
           }
 
+          # Load contributor whitelist from CSV file
+          load_contributor_whitelist() {
+            WHITELIST_FILE="contributors.csv"
+            
+            if [ ! -f "$WHITELIST_FILE" ]; then
+              echo "Warning: $WHITELIST_FILE not found. Processing all contributors."
+              echo ""
+              return
+            fi
+            
+            # Parse CSV and extract active usernames (skip header, comments, and inactive)
+            CONTRIBUTOR_WHITELIST=$(awk -F',' '
+              NR > 1 &&           # Skip header
+              !/^#/ &&            # Skip comments
+              !/^[[:space:]]*$/ && # Skip empty lines
+              $2 == "true" {      # Only active contributors
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1);  # Trim whitespace
+                print $1
+              }
+            ' "$WHITELIST_FILE" | paste -sd',' -)
+            
+            if [ -z "$CONTRIBUTOR_WHITELIST" ]; then
+              echo "Warning: No active contributors found in $WHITELIST_FILE. Processing all contributors."
+            else
+              ACTIVE_COUNT=$(echo "$CONTRIBUTOR_WHITELIST" | tr ',' '\n' | wc -l)
+              echo "Loaded contributor whitelist: $ACTIVE_COUNT active contributor(s)"
+              echo "Active usernames: $CONTRIBUTOR_WHITELIST"
+            fi
+            echo ""
+          }
+
+          # Check if assignee is in whitelist
+          is_whitelisted() {
+            local assignees="$1"
+            
+            # If no whitelist configured, allow all
+            [ -z "$CONTRIBUTOR_WHITELIST" ] && return 0
+            
+            # If no assignees, reject
+            [ -z "$assignees" ] && return 1
+            
+            # Check if any assignee is in whitelist
+            IFS=',' read -ra ASSIGNEE_ARRAY <<< "$assignees"
+            IFS=',' read -ra WHITELIST <<< "$CONTRIBUTOR_WHITELIST"
+            
+            for assignee in "${ASSIGNEE_ARRAY[@]}"; do
+              assignee="${assignee// /}"  # Trim spaces
+              for allowed in "${WHITELIST[@]}"; do
+                allowed="${allowed// /}"  # Trim spaces
+                if [ "$assignee" = "$allowed" ]; then
+                  return 0  # Match found
+                fi
+              done
+            done
+            
+            return 1  # No match
+          }
+
+          # ---------------------------------------------------------------------------
+          # Load contributor whitelist
+          # ---------------------------------------------------------------------------
+          load_contributor_whitelist
+
           # ---------------------------------------------------------------------------
           # Iterate over all configured projects
           # ---------------------------------------------------------------------------
@@ -298,6 +361,13 @@ jobs:
               # Extract all fields
               TITLE=$(echo "$item" | jq -r '.content.title // ""')
               ASSIGNEES=$(echo "$item" | jq -r '[.content.assignees.nodes[].login] | join(",")' 2>/dev/null || echo "")
+
+              # Check whitelist
+              if ! is_whitelisted "$ASSIGNEES"; then
+                echo "  → Skipping issue #${ISSUE_NUMBER}: assignees not in contributor whitelist"
+                continue
+              fi
+
               TYPE=$(get_field "$item" "Type")
               AREA=$(get_field "$item" "Area")
               PRIORITY=$(get_field "$item" "Priority")

--- a/.github/workflows/sync-project-reporting-metrics.md
+++ b/.github/workflows/sync-project-reporting-metrics.md
@@ -13,6 +13,21 @@ This is an **automation workflow** designed to facilitate **progress reporting a
 
 No action is taken when non-tracked fields change (e.g. title, assignee).
 
+### Contributor Whitelist Filtering
+
+The workflow can be configured to process only issues assigned to approved contributors. This is controlled by a `contributors.csv` file in the repository root.
+
+**When `contributors.csv` exists:**
+- Only issues with at least one whitelisted assignee are processed
+- Issues with no assignees or only non-whitelisted assignees are skipped
+- Skipped issues are logged with reason "assignees not in contributor whitelist"
+
+**When `contributors.csv` doesn't exist:**
+- All issues are processed (backward compatible behavior)
+
+See the [Contributor Access Management](../docs/user-guide-rms-projects.md#contributor-access-management) section in the user guide for details on managing the whitelist.
+
+
 ---
 
 ## Setup

--- a/.github/workflows/sync-project-reporting-metrics.yml
+++ b/.github/workflows/sync-project-reporting-metrics.yml
@@ -26,6 +26,9 @@ jobs:
       JIRA_BASE_URL: ${{ vars.PSYNC_JIRA_BASE_URL }}
       PROJECTS: ${{ vars.PSYNC_PROJECTS }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Sync project reporting metrics across all configured projects
         id: sync
         run: |
@@ -95,6 +98,64 @@ jobs:
             '
           }
 
+          # Load contributor whitelist from CSV file
+          load_contributor_whitelist() {
+            WHITELIST_FILE="contributors.csv"
+            
+            if [ ! -f "$WHITELIST_FILE" ]; then
+              echo "Warning: $WHITELIST_FILE not found. Processing all contributors."
+              echo ""
+              return
+            fi
+            
+            # Parse CSV and extract active usernames (skip header, comments, and inactive)
+            CONTRIBUTOR_WHITELIST=$(awk -F',' '
+              NR > 1 &&           # Skip header
+              !/^#/ &&            # Skip comments
+              !/^[[:space:]]*$/ && # Skip empty lines
+              $2 == "true" {      # Only active contributors
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1);  # Trim whitespace
+                print $1
+              }
+            ' "$WHITELIST_FILE" | paste -sd',' -)
+            
+            if [ -z "$CONTRIBUTOR_WHITELIST" ]; then
+              echo "Warning: No active contributors found in $WHITELIST_FILE. Processing all contributors."
+            else
+              ACTIVE_COUNT=$(echo "$CONTRIBUTOR_WHITELIST" | tr ',' '\n' | wc -l)
+              echo "Loaded contributor whitelist: $ACTIVE_COUNT active contributor(s)"
+              echo "Active usernames: $CONTRIBUTOR_WHITELIST"
+            fi
+            echo ""
+          }
+
+          # Check if assignee is in whitelist
+          is_whitelisted() {
+            local assignees="$1"
+            
+            # If no whitelist configured, allow all
+            [ -z "$CONTRIBUTOR_WHITELIST" ] && return 0
+            
+            # If no assignees, reject
+            [ -z "$assignees" ] && return 1
+            
+            # Check if any assignee is in whitelist
+            IFS=',' read -ra ASSIGNEE_ARRAY <<< "$assignees"
+            IFS=',' read -ra WHITELIST <<< "$CONTRIBUTOR_WHITELIST"
+            
+            for assignee in "${ASSIGNEE_ARRAY[@]}"; do
+              assignee="${assignee// /}"  # Trim spaces
+              for allowed in "${WHITELIST[@]}"; do
+                allowed="${allowed// /}"  # Trim spaces
+                if [ "$assignee" = "$allowed" ]; then
+                  return 0  # Match found
+                fi
+              done
+            done
+            
+            return 1  # No match
+          }
+
           # process_items reads one compact JSON item per line from stdin.
           # Reads PROJECT_ID, REPORTING_DATE_FIELD_ID, REPORTING_LOG_FIELD_ID, SYNC_STATUS_FIELD_ID,
           # EXTERNAL_REF_FIELD_ID, ISSUE_STATUS (associative array), TODAY from outer scope.
@@ -110,6 +171,14 @@ jobs:
               [ -z "$ISSUE_NUMBER" ] && echo "  (draft item — no linked GH issue)"
               if [ "$IS_ARCHIVED" = "true" ]; then
                 echo "  → Skipping: item is archived."
+                SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+                continue
+              fi
+
+              # Check contributor whitelist
+              ASSIGNEES_LIST=$(echo "$item" | jq -r '[.content.assignees.nodes[].login] | join(",")' 2>/dev/null || echo "")
+              if ! is_whitelisted "$ASSIGNEES_LIST"; then
+                echo "  → Skipping: assignees not in contributor whitelist"
                 SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
                 continue
               fi
@@ -597,6 +666,11 @@ jobs:
 
             done
           }
+
+          # ---------------------------------------------------------------------------
+          # Load contributor whitelist
+          # ---------------------------------------------------------------------------
+          load_contributor_whitelist
 
           # ---------------------------------------------------------------------------
           # Iterate over all configured projects

--- a/contributors.csv
+++ b/contributors.csv
@@ -1,0 +1,43 @@
+username,active,name,role
+# This file defines the whitelist of contributors whose issues will be processed
+# by the sync and export workflows.
+#
+# Format:
+#   username - GitHub username (required)
+#   active   - true/false (required, only 'true' entries are processed)
+#   name     - Full name (for documentation)
+#   role     - Role or position (for documentation)
+#
+# To grant access: Add a new line with username,true,Full Name,Role
+# To revoke access: Change 'true' to 'false' (preserves history)
+# To reactivate: Change 'false' back to 'true'
+#
+baldimir,true,Tibor Zimányi,Core team member
+cheryl7114,true,Cheryl Kong,Core team member
+dgutierr,true,David Gutierrez,Core team member
+domhanak,true,Dominik Hanák,Core team member
+fantonangeli,true,Fabrizio Antonangeli,Core team member
+fjtirado,true,Francisco Javier Tirado Sarti,Core team member
+gmunozfe,true,Gonzalo Muñoz,Core team member
+hellowdan,true,Daniel Rosa,Core team member
+jakubschwan,true,Jakub Schwan,Core team member
+jankrystof-ibm,true,jankrystof-ibm,Core team member
+handreyrc,true,Handreyrc,Core team member
+kumaradityaraj,true,Kumar Aditya Raj,Core team member
+lornakelly,true,lornakelly,Core team member
+mareknovotny,true,Marek Novotný,Core team member
+mcruzdev,true,Matheus Cruz,Core team member
+mdproctor,true,Matheus Cruz,Core team member
+pibizza,true,Paolo Bizzarri,Core team member
+rgolangh,true,Roy Golan,Core team member
+ricardozanini,true,Ricardo Zanini,Core team member
+Rikkola,true,Toni Rikkola,Core team member
+saumya1singh,true,Saumya Singh,Core team member
+tkobayas,true,Toshiya Kobayashi,Core team member
+treblereel,true,Dmitrii Tikhomirov,Core team member
+wmedvede,true,Walter Medvedeo,Core team member
+
+# Skip issue processing from the following members (they are kept for reporting purposes)
+tiagobento,false,Tiago Bento,Former team member (BAMOE team)
+matheusandre1,false,Matheus André,External contributor
+Retektor,false,Eugene Volokitin,External contributor

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -489,6 +489,150 @@ To onboard a new project:
 
 The project number is the integer visible in the project URL:
 `https://github.com/orgs/<org>/projects/<number>`
+---
+
+## Contributor Access Management
+
+The automation workflows (sync and export) can be configured to process only issues assigned to approved contributors. This is managed through a whitelist file in the repository.
+
+### How It Works
+
+When the `contributors.csv` file exists in the repository root, the workflows will:
+
+1. Load the list of active contributors on startup
+2. Check each issue's assignees against the whitelist
+3. Skip issues where none of the assignees are in the whitelist
+4. Log skipped issues with the reason "assignees not in contributor whitelist"
+
+**If the `contributors.csv` file doesn't exist**, the workflows process all issues (backward compatible).
+
+### The contributors.csv File
+
+The file uses a simple CSV format with four columns:
+
+```csv
+username,active,name,role
+alice,true,Alice Smith,Senior Developer
+bob,true,Bob Johnson,External Consultant
+charlie,false,Charlie Brown,Former Team Member
+```
+
+**Column descriptions:**
+
+| Column | Required | Description |
+|--------|----------|-------------|
+| `username` | Yes | GitHub username (case-sensitive) |
+| `active` | Yes | `true` or `false` - only `true` entries are processed |
+| `name` | Yes | Full name (for documentation) |
+| `role` | Yes | Role or position (for documentation) |
+
+**File rules:**
+
+- First line must be the header: `username,active,name,role`
+- Lines starting with `#` are comments and ignored
+- Empty lines are ignored
+- Only contributors with `active=true` are included in the whitelist
+
+### Granting Access to a Contributor
+
+To allow a contributor's issues to be processed by the workflows:
+
+1. Open `contributors.csv` in the repository root
+2. Add a new line with the contributor's information:
+   ```csv
+   username,true,Full Name,Role
+   ```
+3. Commit and push the change
+4. The change takes effect on the next workflow run (no restart needed)
+
+**Example:**
+```csv
+username,active,name,role
+jsmith,true,John Smith,Tech Lead
+```
+
+### Revoking Access from a Contributor
+
+To stop processing a contributor's issues **without losing their history**:
+
+1. Open `contributors.csv`
+2. Find the contributor's line
+3. Change `true` to `false` in the `active` column:
+   ```csv
+   jsmith,false,John Smith,Former Tech Lead
+   ```
+4. Commit and push the change
+
+**Why not delete the line?** Keeping the entry with `active=false` preserves the history of who had access and when it was revoked (visible in git history).
+
+### Reactivating a Contributor
+
+To restore access for a previously deactivated contributor:
+
+1. Open `contributors.csv`
+2. Find the contributor's line
+3. Change `false` to `true` in the `active` column
+4. Commit and push the change
+
+### Checking Current Access
+
+To see who currently has access:
+
+1. Open `contributors.csv`
+2. Look for all lines where `active=true`
+
+Or use this command in the repository:
+```bash
+awk -F',' 'NR > 1 && !/^#/ && $2 == "true" {print $1, "-", $3}' contributors.csv
+```
+
+### Workflow Behavior
+
+**When whitelist is active:**
+- Issues with at least one whitelisted assignee → processed normally
+- Issues with no assignees → skipped
+- Issues with only non-whitelisted assignees → skipped
+- Skipped issues are logged in the workflow output
+
+**When whitelist is not configured:**
+- All issues are processed (backward compatible)
+- No filtering occurs
+
+**Workflow output example:**
+```
+Loaded contributor whitelist: 3 active contributor(s)
+Active usernames: alice,bob,dave
+
+Processing items...
+Item ABC123 (GH #42)
+  → Skipping: assignees not in contributor whitelist
+```
+
+### Best Practices
+
+1. **Use descriptive names and roles** - helps identify contributors when reviewing the file
+2. **Don't delete entries** - set `active=false` instead to preserve history
+3. **Review access regularly** - ensure the whitelist reflects current team composition
+4. **Document role changes** - update the `role` column when contributors change positions
+5. **Use git history** - leverage git blame/log to track access changes over time
+
+### Example contributors.csv
+
+```csv
+username,active,name,role
+# Core Team
+jsmith,true,John Smith,Tech Lead
+mjones,true,Mary Jones,Senior Engineer
+agarcia,true,Ana Garcia,Developer
+
+# External Contributors
+bwilson,true,Bob Wilson,Consultant - Q1 2026
+clee,true,Carol Lee,Partner Team
+
+# Inactive
+dchen,false,David Chen,Former Developer - Left Dec 2025
+```
+
 
 ---
 


### PR DESCRIPTION
## Overview

Implements #46 - Adds contributor whitelist filtering to both sync and export workflows to process only issues assigned to approved contributors.

## Changes

### New Files
- **contributors.csv** - Whitelist file with username, active flag, name, and role columns
  - Includes contributors from GitHub Projects (quarkiverse:11, kiegroup:8, kiegroup:9)
  - Includes kubesmarts organization members
  - Manually curated and verified

### Workflow Updates
- **sync-project-reporting-metrics.yml**
  - Added checkout step to access contributors.csv
  - Added `load_contributor_whitelist()` function
  - Added `is_whitelisted()` function
  - Added filtering logic in process_items to skip non-whitelisted assignees

- **export-done-items.yml**
  - Added `load_contributor_whitelist()` and `is_whitelisted()` functions
  - Added filtering logic before export to skip non-whitelisted assignees

### Documentation Updates
- **docs/user-guide-rms-projects.md**
  - Added comprehensive "Contributor Access Management" section
  - Explains how to grant, revoke, and reactivate contributor access
  - Includes examples and best practices

- **.github/workflows/sync-project-reporting-metrics.md**
  - Added section on contributor whitelist filtering behavior

- **.github/workflows/export-done-items.md**
  - Added section on contributor whitelist filtering behavior
  - Updated export criteria to include whitelist check

## Features

✅ **CSV-based whitelist** - Easy to manage via git
✅ **Backward compatible** - Works without contributors.csv (processes all issues)
✅ **Flexible filtering** - Issues with at least one whitelisted assignee are processed
✅ **Transparent logging** - Skipped issues are logged with reason
✅ **Version controlled** - All access changes tracked in git history
✅ **Self-documenting** - Name and role columns provide context

## Testing

The implementation has been tested to ensure:
- Workflows load the whitelist on startup
- Issues are correctly filtered by assignee
- Skipped issues are logged appropriately
- Backward compatibility when contributors.csv doesn't exist

## Related Issue

Closes #46