### PR TITLE
feat(compliance): add IN_PROGRESS_NO_WORK_REMAINING

### DIFF
--- a/.github/workflows/gh-issues-compliance-checker.md
+++ b/.github/workflows/gh-issues-compliance-checker.md
@@ -106,6 +106,7 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 | `NO_ESTIMATE` | `Estimate` is empty and the item's `Status` is neither `Backlog` nor `Next` |
 | `ESTIMATE_TOO_LONG` | `Estimate` is set but exceeds 2 weeks and the item's `Status` is `In Progress` |
 | `NO_REMAINING_WORK` | `Remaining Work` is empty and `Status` is `In Progress` or `In Review` (not raised for `Done` — field is auto-cleared) |
+| `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is explicitly `0` and `Status` is `In Progress` — work appears complete but status has not been updated |
 | `NO_AREA` | `Area` is empty and `Status` is not `Backlog` |
 | `NO_PRIORITY` | `Priority` is empty and `Status` is not `Backlog` |
 | `NO_MILESTONE` | `Target Milestone` is empty and `Status` is not `Backlog` |
@@ -296,6 +297,7 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **Project in a different org not processed** → the PAT owner must be a member of that org; for SAML SSO orgs the PAT must be authorized via **GitHub → Settings → Personal access tokens → Configure SSO → Authorize**
 - **`Alerts` field not updated** → the field name must be exactly `Alerts` (case-sensitive) and its type must be Text; if absent, the field is silently skipped and a note appears in the Actions log (`not configured`)
 - **`Alerts` shows `NO_ESTIMATE` or `NO_REMAINING_WORK`** → set the missing field on the project item, or move the item back to `Backlog` / `Next` status if estimation is not yet applicable
+- **`Alerts` shows `IN_PROGRESS_NO_WORK_REMAINING`** → `Remaining Work` is `0` but the item is still `In Progress`; if the work is done, move the status to `In Review` or `Done`, otherwise set the remaining effort to the correct non-zero value
 - **`Alerts` shows `ESTIMATE_TOO_LONG`** → the item's `Estimate` is greater than 2 weeks and it is `In Progress`; consider breaking it down into smaller pieces of work, or move it back to `Backlog` / `Next` if the large estimate is intentional at this stage
 - **`Alerts` shows `NO_AREA`** → set the `Area` field on the project item, or move it back to `Backlog` if area classification is not yet applicable
 - **`Alerts` shows `NO_PRIORITY`** → set the `Priority` field on the project item, or move it back to `Backlog` if prioritization is not yet applicable

--- a/.github/workflows/gh-issues-compliance-checker.md
+++ b/.github/workflows/gh-issues-compliance-checker.md
@@ -106,7 +106,7 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 | `NO_ESTIMATE` | `Estimate` is empty and the item's `Status` is neither `Backlog` nor `Next` |
 | `ESTIMATE_TOO_LONG` | `Estimate` is set but exceeds 2 weeks and the item's `Status` is `In Progress` |
 | `NO_REMAINING_WORK` | `Remaining Work` is empty and `Status` is `In Progress` or `In Review` (not raised for `Done` — field is auto-cleared) |
-| `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is explicitly `0` and `Status` is `In Progress` — work appears complete but status has not been updated |
+| `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is explicitly `0`, `Estimate` is greater than `0`, and `Status` is `In Progress` — work appears complete but status has not been updated (not raised for zero-estimate items) |
 | `NO_AREA` | `Area` is empty and `Status` is not `Backlog` |
 | `NO_PRIORITY` | `Priority` is empty and `Status` is not `Backlog` |
 | `NO_MILESTONE` | `Target Milestone` is empty and `Status` is not `Backlog` |
@@ -297,7 +297,7 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **Project in a different org not processed** → the PAT owner must be a member of that org; for SAML SSO orgs the PAT must be authorized via **GitHub → Settings → Personal access tokens → Configure SSO → Authorize**
 - **`Alerts` field not updated** → the field name must be exactly `Alerts` (case-sensitive) and its type must be Text; if absent, the field is silently skipped and a note appears in the Actions log (`not configured`)
 - **`Alerts` shows `NO_ESTIMATE` or `NO_REMAINING_WORK`** → set the missing field on the project item, or move the item back to `Backlog` / `Next` status if estimation is not yet applicable
-- **`Alerts` shows `IN_PROGRESS_NO_WORK_REMAINING`** → `Remaining Work` is `0` but the item is still `In Progress`; if the work is done, move the status to `In Review` or `Done`, otherwise set the remaining effort to the correct non-zero value
+- **`Alerts` shows `IN_PROGRESS_NO_WORK_REMAINING`** → `Remaining Work` is `0` and `Estimate` is greater than `0` but the item is still `In Progress`; if the work is done, move the status to `In Review` or `Done`, otherwise set the remaining effort to the correct non-zero value
 - **`Alerts` shows `ESTIMATE_TOO_LONG`** → the item's `Estimate` is greater than 2 weeks and it is `In Progress`; consider breaking it down into smaller pieces of work, or move it back to `Backlog` / `Next` if the large estimate is intentional at this stage
 - **`Alerts` shows `NO_AREA`** → set the `Area` field on the project item, or move it back to `Backlog` if area classification is not yet applicable
 - **`Alerts` shows `NO_PRIORITY`** → set the `Priority` field on the project item, or move it back to `Backlog` if prioritization is not yet applicable

--- a/.github/workflows/gh-issues-compliance-checker.yml
+++ b/.github/workflows/gh-issues-compliance-checker.yml
@@ -307,6 +307,10 @@ jobs:
               if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ "$STATUS_LC" != "done" ] && [ -z "$REMAINING_WORK" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
               fi
+              if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$REMAINING_WORK" ] && \
+                 awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }'; then
+                SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }IN_PROGRESS_NO_WORK_REMAINING"
+              fi
               if [ -n "$AREA_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$AREA" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_AREA"
               fi

--- a/.github/workflows/gh-issues-compliance-checker.yml
+++ b/.github/workflows/gh-issues-compliance-checker.yml
@@ -308,7 +308,8 @@ jobs:
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
               fi
               if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$REMAINING_WORK" ] && \
-                 awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }'; then
+                 awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }' && \
+                 awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 > 0) }'; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }IN_PROGRESS_NO_WORK_REMAINING"
               fi
               if [ -n "$AREA_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$AREA" ]; then

--- a/.github/workflows/scripts/gh-issues-compliance-checker.test.js
+++ b/.github/workflows/scripts/gh-issues-compliance-checker.test.js
@@ -201,6 +201,12 @@ if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" !=
   SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
 fi
 
+# IN_PROGRESS_NO_WORK_REMAINING
+if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$REMAINING_WORK" ] && \
+   awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }'; then
+  SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }IN_PROGRESS_NO_WORK_REMAINING"
+fi
+
 # NO_AREA
 if [ -n "$AREA_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ -z "$AREA" ]; then
   SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }NO_AREA"
@@ -295,6 +301,45 @@ test('NO_REMAINING_WORK: not raised when remaining work is set', () => {
   const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0.5' });
   assert.ok(!codes.includes('NO_REMAINING_WORK'), `Unexpected NO_REMAINING_WORK when set: "${codes}"`);
 });
+
+
+// -- IN_PROGRESS_NO_WORK_REMAINING --
+
+test('IN_PROGRESS_NO_WORK_REMAINING: raised when in-progress item has remaining work of 0', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0' });
+  assert.ok(codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Expected IN_PROGRESS_NO_WORK_REMAINING, got: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: raised when in-progress item has remaining work of 0.0', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0.0' });
+  assert.ok(codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Expected IN_PROGRESS_NO_WORK_REMAINING for 0.0, got: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised when remaining work is a positive value', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0.5' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING when set: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised when remaining work is empty (NO_REMAINING_WORK handles that)', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING for empty value: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised for done items', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'done', REMAINING_WORK: '0' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING for done: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised for backlog items', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'backlog', REMAINING_WORK: '0' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING for backlog: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised when remaining work field is not configured', () => {
+  const codes = evalRule({ ...ALL_FIELDS, REMAINING_WORK_FIELD_ID: '', STATUS_LC: 'in progress', REMAINING_WORK: '0' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING when field absent: "${codes}"`);
+});
+
 
 // -- NO_AREA --
 

--- a/.github/workflows/scripts/gh-issues-compliance-checker.test.js
+++ b/.github/workflows/scripts/gh-issues-compliance-checker.test.js
@@ -203,7 +203,8 @@ fi
 
 # IN_PROGRESS_NO_WORK_REMAINING
 if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$REMAINING_WORK" ] && \
-   awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }'; then
+   awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }' && \
+   awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 > 0) }'; then
   SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }IN_PROGRESS_NO_WORK_REMAINING"
 fi
 
@@ -305,13 +306,13 @@ test('NO_REMAINING_WORK: not raised when remaining work is set', () => {
 
 // -- IN_PROGRESS_NO_WORK_REMAINING --
 
-test('IN_PROGRESS_NO_WORK_REMAINING: raised when in-progress item has remaining work of 0', () => {
-  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0' });
+test('IN_PROGRESS_NO_WORK_REMAINING: raised when in-progress item has remaining work of 0 and estimate > 0', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0', ESTIMATE: '1' });
   assert.ok(codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Expected IN_PROGRESS_NO_WORK_REMAINING, got: "${codes}"`);
 });
 
-test('IN_PROGRESS_NO_WORK_REMAINING: raised when in-progress item has remaining work of 0.0', () => {
-  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0.0' });
+test('IN_PROGRESS_NO_WORK_REMAINING: raised when in-progress item has remaining work of 0.0 and estimate > 0', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0.0', ESTIMATE: '1' });
   assert.ok(codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Expected IN_PROGRESS_NO_WORK_REMAINING for 0.0, got: "${codes}"`);
 });
 
@@ -338,6 +339,16 @@ test('IN_PROGRESS_NO_WORK_REMAINING: not raised for backlog items', () => {
 test('IN_PROGRESS_NO_WORK_REMAINING: not raised when remaining work field is not configured', () => {
   const codes = evalRule({ ...ALL_FIELDS, REMAINING_WORK_FIELD_ID: '', STATUS_LC: 'in progress', REMAINING_WORK: '0' });
   assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING when field absent: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised when estimate is 0 (zero-effort item)', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0', ESTIMATE: '0' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING when estimate is 0: "${codes}"`);
+});
+
+test('IN_PROGRESS_NO_WORK_REMAINING: not raised when estimate is absent', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0', ESTIMATE: '' });
+  assert.ok(!codes.includes('IN_PROGRESS_NO_WORK_REMAINING'), `Unexpected IN_PROGRESS_NO_WORK_REMAINING when estimate absent: "${codes}"`);
 });
 
 

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -189,7 +189,7 @@ Please review and resolve these alerts.
 | `NO_ESTIMATE` | `Estimate` is empty and status is past `Next` | Set the `Estimate` field |
 | `ESTIMATE_TOO_LONG` | `Estimate` exceeds 2 weeks and status is `In Progress` | Break the work item into smaller pieces, or move it back to `Backlog` / `Next` if the large estimate is intentional at this stage |
 | `NO_REMAINING_WORK` | `Remaining Work` is empty and status is `In Progress` or `In Review` | Set the `Remaining Work` field |
-| `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is `0` and status is `In Progress` — work appears complete but status not updated | Move status to `In Review` or `Done`, or set the remaining effort to the correct non-zero value |
+| `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is `0`, `Estimate` is greater than `0`, and status is `In Progress` — work appears complete but status not updated (not raised for zero-estimate items) | Move status to `In Review` or `Done`, or set the remaining effort to the correct non-zero value |
 | `NO_TIME_SPENT` | `Time Spent` is empty and status is `Done` | Enter the total time spent |
 | `NO_ASSIGNEE` | No assignee on the GH issue and status is `In Progress`, `In Review`, or `Done` | Assign the issue to the responsible person |
 | `CHILDREN_STATUS` | Parent/child status mismatch detected (see below) | Align child statuses with the parent |

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -189,6 +189,7 @@ Please review and resolve these alerts.
 | `NO_ESTIMATE` | `Estimate` is empty and status is past `Next` | Set the `Estimate` field |
 | `ESTIMATE_TOO_LONG` | `Estimate` exceeds 2 weeks and status is `In Progress` | Break the work item into smaller pieces, or move it back to `Backlog` / `Next` if the large estimate is intentional at this stage |
 | `NO_REMAINING_WORK` | `Remaining Work` is empty and status is `In Progress` or `In Review` | Set the `Remaining Work` field |
+| `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is `0` and status is `In Progress` — work appears complete but status not updated | Move status to `In Review` or `Done`, or set the remaining effort to the correct non-zero value |
 | `NO_TIME_SPENT` | `Time Spent` is empty and status is `Done` | Enter the total time spent |
 | `NO_ASSIGNEE` | No assignee on the GH issue and status is `In Progress`, `In Review`, or `Done` | Assign the issue to the responsible person |
 | `CHILDREN_STATUS` | Parent/child status mismatch detected (see below) | Align child statuses with the parent |


### PR DESCRIPTION
Alert for zero remaining work when status is set to 'in progress'

Detect in-progress items whose Remaining Work is explicitly set to 0.0 with status set to 'In progress', indicating the issue is ready to be moved to 'in review' or 'done'. Separate from NO_REMAINING_WORK for empty values.

- add workflow rule for IN_PROGRESS_NO_WORK_REMAINING
- extend compliance checker tests for zero/empty/positive remaining work cases
- document the new alert code and troubleshooting guidance
- update user guide where end-user alert codes are referenced

Closes #73