### PR TITLE
fix(compliance): suppress NO_ESTIMATE and conditionally suppress NO_REMAINING_WORK for epics

### DIFF
--- a/.github/workflows/gh-issues-compliance-checker.md
+++ b/.github/workflows/gh-issues-compliance-checker.md
@@ -109,9 +109,9 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 
 | Code | When set |
 |------|----------|
-| `NO_ESTIMATE` | `Estimate` is empty and the item's `Status` is neither `Backlog` nor `Next` |
+| `NO_ESTIMATE` | `Estimate` is empty, the item's `Status` is neither `Backlog` nor `Next`, **and the item is not an epic** (epics may have no estimate when all work is tracked in sub-issues) |
 | `ESTIMATE_TOO_LONG` | `Estimate` is set but exceeds 2 weeks and the item's `Status` is `In Progress` |
-| `NO_REMAINING_WORK` | `Remaining Work` is empty and `Status` is `In Progress` or `In Review` (not raised for `Done` — field is auto-cleared) |
+| `NO_REMAINING_WORK` | `Remaining Work` is empty and `Status` is `In Progress` or `In Review` (not raised for `Done` — field is auto-cleared). **For epics, only raised when `Estimate` is greater than 0** — if no estimate is set on the epic itself, remaining work is not required |
 | `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is explicitly `0`, `Estimate` is greater than `0`, and `Status` is `In Progress` — work appears complete but status has not been updated (not raised for zero-estimate items) |
 | `NO_AREA` | `Area` is empty and `Status` is not `Backlog` |
 | `NO_PRIORITY` | `Priority` is empty and `Status` is not `Backlog` |
@@ -302,7 +302,8 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **Item not processed** → the workflow paginates (100 items per page); check the log to confirm the item's page was fetched
 - **Project in a different org not processed** → the PAT owner must be a member of that org; for SAML SSO orgs the PAT must be authorized via **GitHub → Settings → Personal access tokens → Configure SSO → Authorize**
 - **`Alerts` field not updated** → the field name must be exactly `Alerts` (case-sensitive) and its type must be Text; if absent, the field is silently skipped and a note appears in the Actions log (`not configured`)
-- **`Alerts` shows `NO_ESTIMATE` or `NO_REMAINING_WORK`** → set the missing field on the project item, or move the item back to `Backlog` / `Next` status if estimation is not yet applicable
+- **`Alerts` shows `NO_ESTIMATE`** → set the `Estimate` field on the project item, or move the item back to `Backlog` / `Next` if estimation is not yet applicable. Note: epics (items with sub-issues) never trigger `NO_ESTIMATE` — estimate is optional for them
+- **`Alerts` shows `NO_REMAINING_WORK`** → set the `Remaining Work` field. For epics this alert only fires when their own `Estimate` is greater than 0 — set remaining work to the appropriate value, or set `Estimate` to `0` if all work is tracked in sub-issues
 - **`Alerts` shows `IN_PROGRESS_NO_WORK_REMAINING`** → `Remaining Work` is `0` and `Estimate` is greater than `0` but the item is still `In Progress`; if the work is done, move the status to `In Review` or `Done`, otherwise set the remaining effort to the correct non-zero value
 - **`Alerts` shows `ESTIMATE_TOO_LONG`** → the item's `Estimate` is greater than 2 weeks and it is `In Progress`; consider breaking it down into smaller pieces of work, or move it back to `Backlog` / `Next` if the large estimate is intentional at this stage
 - **`Alerts` shows `NO_AREA`** → set the `Area` field on the project item, or move it back to `Backlog` if area classification is not yet applicable

--- a/.github/workflows/gh-issues-compliance-checker.yml
+++ b/.github/workflows/gh-issues-compliance-checker.yml
@@ -240,6 +240,9 @@ jobs:
               # Compute Alerts codes (validation rules, always evaluated regardless of changes)
               SYNC_STATUS_CODES=""
 
+              # Determine whether this item is an epic (has at least one sub-issue in the graph).
+              HAS_SUB_ISSUES=$(echo "$item" | jq -r 'if (.content.subIssues.nodes // [] | length) > 0 then "true" else "false" end')
+
               # Handle JIRA ticket creation if External Reference is a CREATE directive.
               # Pattern: "CREATE <projectKey> [<component>]"  e.g. "CREATE QUARKUS quarkus-flow"
               # On success: EXTERNAL_REF is set to the new JIRA key and LAST_STATUS is cleared
@@ -309,15 +312,19 @@ jobs:
                   fi
                 fi
               fi
-              if [ -n "$ESTIMATE_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ -z "$ESTIMATE" ]; then
+              # NO_ESTIMATE: suppressed for epics (estimate is optional on epics).
+              if [ -n "$ESTIMATE_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ -z "$ESTIMATE" ] && [ "$HAS_SUB_ISSUES" != "true" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_ESTIMATE"
               fi
               if [ -n "$ESTIMATE_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$ESTIMATE" ] && \
                  awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 > 2) }'; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }ESTIMATE_TOO_LONG"
               fi
+              # NO_REMAINING_WORK: for epics, only raised when estimate is set and > 0.
               if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ "$STATUS_LC" != "done" ] && [ -z "$REMAINING_WORK" ]; then
-                SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
+                if [ "$HAS_SUB_ISSUES" != "true" ] || awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 > 0) }'; then
+                  SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
+                fi
               fi
               if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$REMAINING_WORK" ] && \
                  awk -v r="$REMAINING_WORK" 'BEGIN { exit !(r+0 == 0) }' && \

--- a/.github/workflows/jira-compliance-checker-spec.md
+++ b/.github/workflows/jira-compliance-checker-spec.md
@@ -23,8 +23,8 @@ A GitHub Actions workflow that validates JIRA issues against ABLE team's softwar
 | Area | area/\<value\> label | Label | Must have one label matching pattern `area/*` (e.g., area/ci, area/runtimes, area/tooling, area/cloud, area/qe, area/docs). For SRVLOGIC issues, automatically synced with Component field |
 | Priority | Priority | Single select | Must be set to one of: Blocker, Critical, Major, Normal, Minor |
 | Version | Fix Versions | Array | Must have at least one version set |
-| Estimate | Original Estimate | Time tracking | Must be set (any positive value) |
-| Remaining Work | Remaining Estimate | Time tracking | Must be set (any positive value) |
+| Estimate | Original Estimate | Time tracking | Must be set (any positive value). **Optional for epics** (issues with sub-tasks) |
+| Remaining Work | Remaining Estimate | Time tracking | Must be set (any positive value). **For epics, only required when their own Original Estimate is > 0** |
 | Time Spent | Time Spent (worklog sum) | Time tracking | Must be set (can be 0, but field must exist/not be null) |
 | Assignee | Assignee | User | Must have at least one assignee |
 
@@ -204,8 +204,8 @@ for (label in labelsToRemove) {
 | `NO_AREA` | No area/* label found | Required for Next, In Progress, In Review, Done (after Component/Area sync for SRVLOGIC) |
 | `NO_PRIORITY` | Priority field is empty | Required for Next, In Progress, In Review, Done |
 | `NO_VERSION` | Fix Versions is empty | Required for Next, In Progress, In Review, Done |
-| `NO_ESTIMATE` | Original Estimate is empty | Required for In Progress, In Review, Done |
-| `NO_REMAINING_WORK` | Remaining Estimate is empty | Required for In Progress, In Review |
+| `NO_ESTIMATE` | Original Estimate is empty | Required for In Progress, In Review, Done — **suppressed for epics** (issues with sub-tasks) |
+| `NO_REMAINING_WORK` | Remaining Estimate is empty | Required for In Progress, In Review — **suppressed for epics when their Original Estimate is ≤ 0** |
 | `NO_TIME_SPENT` | Time Spent field is null/not set | Required for Done (value can be 0, but field must exist) |
 | `NO_ASSIGNEE` | Assignee field is empty | Required for In Progress, In Review, Done |
 | `REMAINING_WORK_NOT_CLEARED` | Remaining Estimate > 0 when Done | Status is Done but Remaining Estimate not cleared |

--- a/.github/workflows/jira-compliance-checker.md
+++ b/.github/workflows/jira-compliance-checker.md
@@ -76,9 +76,9 @@ Compliance alert codes:
 | `NO_AREA` | Missing area/* label |
 | `NO_PRIORITY` | Missing priority |
 | `NO_VERSION` | Missing fix versions |
-| `NO_ESTIMATE` | Missing original estimate |
+| `NO_ESTIMATE` | Missing original estimate. **Not raised for epics** (issues with sub-tasks) — estimate is optional for them |
 | `ESTIMATE_TOO_LONG` | Original estimate exceeds 2 weeks and status is `In Progress` |
-| `NO_REMAINING_WORK` | Missing remaining estimate |
+| `NO_REMAINING_WORK` | Missing remaining estimate. **For epics, only raised when their original estimate is > 0** |
 | `NO_TIME_SPENT` | Missing time spent |
 | `NO_ASSIGNEE` | Missing assignee |
 | `REMAINING_WORK_NOT_CLEARED` | Remaining work not cleared when Done (auto-cleared by the workflow) |

--- a/.github/workflows/scripts/gh-issues-compliance-checker.test.js
+++ b/.github/workflows/scripts/gh-issues-compliance-checker.test.js
@@ -191,14 +191,16 @@ function evalRule(vars) {
 ${assignments}
 SYNC_STATUS_CODES=""
 
-# NO_ESTIMATE
-if [ -n "$ESTIMATE_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ -z "$ESTIMATE" ]; then
+# NO_ESTIMATE: suppressed for epics (estimate is optional on epics).
+if [ -n "$ESTIMATE_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ -z "$ESTIMATE" ] && [ "$HAS_SUB_ISSUES" != "true" ]; then
   SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }NO_ESTIMATE"
 fi
 
-# NO_REMAINING_WORK
+# NO_REMAINING_WORK: for epics, only raised when estimate is set and > 0.
 if [ -n "$REMAINING_WORK_FIELD_ID" ] && [ -n "$STATUS_LC" ] && [ "$STATUS_LC" != "backlog" ] && [ "$STATUS_LC" != "next" ] && [ "$STATUS_LC" != "done" ] && [ -z "$REMAINING_WORK" ]; then
-  SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
+  if [ "$HAS_SUB_ISSUES" != "true" ] || awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 > 0) }'; then
+    SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }NO_REMAINING_WORK"
+  fi
 fi
 
 # IN_PROGRESS_NO_WORK_REMAINING
@@ -276,6 +278,11 @@ test('NO_ESTIMATE: not raised when field is not configured', () => {
   assert.ok(!codes.includes('NO_ESTIMATE'), `Unexpected NO_ESTIMATE when field absent: "${codes}"`);
 });
 
+test('NO_ESTIMATE: not raised for epic (in-progress, no estimate)', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', ESTIMATE: '', HAS_SUB_ISSUES: 'true' });
+  assert.ok(!codes.includes('NO_ESTIMATE'), `Unexpected NO_ESTIMATE for epic: "${codes}"`);
+});
+
 // -- NO_REMAINING_WORK --
 
 test('NO_REMAINING_WORK: raised for in-progress item with no remaining work', () => {
@@ -301,6 +308,21 @@ test('NO_REMAINING_WORK: not raised for next items', () => {
 test('NO_REMAINING_WORK: not raised when remaining work is set', () => {
   const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '0.5' });
   assert.ok(!codes.includes('NO_REMAINING_WORK'), `Unexpected NO_REMAINING_WORK when set: "${codes}"`);
+});
+
+test('NO_REMAINING_WORK: not raised for epic with no estimate (estimate empty)', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '', ESTIMATE: '', HAS_SUB_ISSUES: 'true' });
+  assert.ok(!codes.includes('NO_REMAINING_WORK'), `Unexpected NO_REMAINING_WORK for epic with no estimate: "${codes}"`);
+});
+
+test('NO_REMAINING_WORK: not raised for epic with zero estimate', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '', ESTIMATE: '0', HAS_SUB_ISSUES: 'true' });
+  assert.ok(!codes.includes('NO_REMAINING_WORK'), `Unexpected NO_REMAINING_WORK for epic with estimate=0: "${codes}"`);
+});
+
+test('NO_REMAINING_WORK: raised for epic when estimate is > 0 and remaining work is empty', () => {
+  const codes = evalRule({ ...ALL_FIELDS, STATUS_LC: 'in progress', REMAINING_WORK: '', ESTIMATE: '1', HAS_SUB_ISSUES: 'true' });
+  assert.ok(codes.includes('NO_REMAINING_WORK'), `Expected NO_REMAINING_WORK for epic with estimate=1: "${codes}"`);
 });
 
 

--- a/.github/workflows/scripts/policy-validator.js
+++ b/.github/workflows/scripts/policy-validator.js
@@ -83,10 +83,19 @@ class PolicyValidator {
         return stage;
     }
 
+    /**
+     * Returns true when the issue is an epic — i.e. it has at least one sub-task/sub-issue.
+     * Both JIRA subtasks and the newer "child issues" are stored in issue.fields.subtasks.
+     */
+    isEpic(issue) {
+        return Array.isArray(issue.fields.subtasks) && issue.fields.subtasks.length > 0;
+    }
+
     validateIssue(issue, jiraClient) {
         const status = jiraClient.extractStatus(issue);
         const policyStage = this.mapStatusToPolicyStage(status);
         const requiredFields = this.requiredFields[policyStage] || [];
+        const epic = this.isEpic(issue);
 
         const violations = [];
         const fieldValues = {
@@ -114,6 +123,15 @@ class PolicyValidator {
             : requiredFields;
 
         for (const field of fieldsToCheck) {
+            // NO_ESTIMATE is suppressed for epics — estimate is optional on epics.
+            if (field === 'originalEstimate' && epic) continue;
+
+            // NO_REMAINING_WORK is suppressed for epics unless their own estimate is > 0.
+            if (field === 'remainingEstimate' && epic) {
+                const estimateSeconds = issue.fields.timetracking?.originalEstimateSeconds ?? 0;
+                if (estimateSeconds <= 0) continue;
+            }
+
             if (!this.isFieldValid(field, fieldValues[field])) {
                 violations.push(this.violationCodes[field]);
             }

--- a/.github/workflows/scripts/policy-validator.test.js
+++ b/.github/workflows/scripts/policy-validator.test.js
@@ -17,7 +17,7 @@ const TWO_WEEKS_S = 2 * ONE_WEEK_S;
  * Only the fields exercised by the ESTIMATE_TOO_LONG rule are required here;
  * all other required fields are pre-populated so other rules don't fire.
  */
-function makeIssue({ status = 'IN PROGRESS', estimateSeconds = null, key = 'TEST-1' } = {}) {
+function makeIssue({ status = 'IN PROGRESS', estimateSeconds = null, key = 'TEST-1', subtasks = [] } = {}) {
     return {
         key,
         fields: {
@@ -28,6 +28,7 @@ function makeIssue({ status = 'IN PROGRESS', estimateSeconds = null, key = 'TEST
             assignee:     { displayName: 'Alice', accountId: 'alice-id' },
             labels:       ['area/runtimes'],
             components:   [],
+            subtasks,
             timetracking: {
                 originalEstimateSeconds:  estimateSeconds,
                 originalEstimate:         estimateSeconds != null ? `${Math.round(estimateSeconds / 3600)}h` : undefined,
@@ -142,4 +143,51 @@ test('ESTIMATE_TOO_LONG: not raised for Done items even with large estimate', ()
     const result = validator.validateIssue(issue, jiraClient);
     assert.ok(!result.violations.includes('ESTIMATE_TOO_LONG'),
         `Unexpected ESTIMATE_TOO_LONG for Done: ${result.violations}`);
+});
+
+// ---------------------------------------------------------------------------
+// Epic suppression tests (NO_ESTIMATE / NO_REMAINING_WORK)
+// ---------------------------------------------------------------------------
+
+/** A stub sub-task entry — only the presence matters for isEpic(). */
+const STUB_SUBTASK = { key: 'TEST-2', fields: { summary: 'child' } };
+
+test('NO_ESTIMATE: not raised for In Progress epic with no estimate', () => {
+    const validator = new PolicyValidator();
+    // Epic with no estimate — originalEstimateSeconds is null
+    const issue = makeIssue({ status: 'IN PROGRESS', estimateSeconds: null, subtasks: [STUB_SUBTASK] });
+    const result = validator.validateIssue(issue, jiraClient);
+    assert.ok(!result.violations.includes('NO_ESTIMATE'),
+        `Unexpected NO_ESTIMATE for epic: ${result.violations}`);
+});
+
+test('NO_ESTIMATE: raised for non-epic In Progress item with no estimate', () => {
+    const validator = new PolicyValidator();
+    // Non-epic (no subtasks) with no estimate — should still fire
+    const issue = makeIssue({ status: 'IN PROGRESS', estimateSeconds: null, subtasks: [] });
+    const result = validator.validateIssue(issue, jiraClient);
+    assert.ok(result.violations.includes('NO_ESTIMATE'),
+        `Expected NO_ESTIMATE for non-epic without estimate: ${result.violations}`);
+});
+
+test('NO_REMAINING_WORK: not raised for In Progress epic with no estimate', () => {
+    const validator = new PolicyValidator();
+    // Epic with estimate=0 — remaining work not mandatory
+    const issue = makeIssue({ status: 'IN PROGRESS', estimateSeconds: 0, subtasks: [STUB_SUBTASK] });
+    const result = validator.validateIssue(issue, jiraClient);
+    assert.ok(!result.violations.includes('NO_REMAINING_WORK'),
+        `Unexpected NO_REMAINING_WORK for epic with estimate=0: ${result.violations}`);
+});
+
+test('NO_REMAINING_WORK: raised for In Progress epic when estimate > 0 and remaining work is absent', () => {
+    const validator = new PolicyValidator();
+    // Epic with a real estimate — remaining work IS required
+    // We need remainingEstimateSeconds to be 0/null to trigger the missing-field path.
+    const issue = makeIssue({ status: 'IN PROGRESS', estimateSeconds: ONE_WEEK_S, subtasks: [STUB_SUBTASK] });
+    // Override remaining to be absent (null) to trigger the rule
+    issue.fields.timetracking.remainingEstimateSeconds = null;
+    issue.fields.timetracking.remainingEstimate = undefined;
+    const result = validator.validateIssue(issue, jiraClient);
+    assert.ok(result.violations.includes('NO_REMAINING_WORK'),
+        `Expected NO_REMAINING_WORK for epic with estimate>0 and no remaining: ${result.violations}`);
 });

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -186,9 +186,9 @@ Please review and resolve these alerts.
 | `NO_AREA` | `Area` is empty and the issue is past `Backlog` | Set the `Area` field |
 | `NO_PRIORITY` | `Priority` is empty and the issue is past `Backlog` | Set the `Priority` field |
 | `NO_MILESTONE` | `Target Milestone` is empty and the issue is past `Backlog` | Set the `Target Milestone` field |
-| `NO_ESTIMATE` | `Estimate` is empty and status is past `Next` | Set the `Estimate` field |
+| `NO_ESTIMATE` | `Estimate` is empty, status is past `Next`, and the issue is not an epic | Set the `Estimate` field. Epics (issues with sub-issues) are exempt — estimate is optional for them |
 | `ESTIMATE_TOO_LONG` | `Estimate` exceeds 2 weeks and status is `In Progress` | Break the work item into smaller pieces, or move it back to `Backlog` / `Next` if the large estimate is intentional at this stage |
-| `NO_REMAINING_WORK` | `Remaining Work` is empty and status is `In Progress` or `In Review` | Set the `Remaining Work` field |
+| `NO_REMAINING_WORK` | `Remaining Work` is empty and status is `In Progress` or `In Review`. For epics, only raised when their own `Estimate` is greater than 0 | Set the `Remaining Work` field. For epics whose all work is in sub-issues, keep `Estimate` at `0` to suppress this alert |
 | `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is `0`, `Estimate` is greater than `0`, and status is `In Progress` — work appears complete but status not updated (not raised for zero-estimate items) | Move status to `In Review` or `Done`, or set the remaining effort to the correct non-zero value |
 | `NO_TIME_SPENT` | `Time Spent` is empty and status is `Done` | Enter the total time spent |
 | `NO_ASSIGNEE` | No assignee on the GH issue and status is `In Progress`, `In Review`, or `Done` | Assign the issue to the responsible person |
@@ -301,6 +301,8 @@ Most Epics serve purely as organizational containers. In this case:
 
 All time tracking should be done in the sub-issues. The Epic itself has no work associated with it.
 
+> **Compliance alerts:** The workflow automatically suppresses `NO_ESTIMATE` for all epics — estimate is optional. `NO_REMAINING_WORK` is also suppressed when the epic's own `Estimate` is `0` or empty. If you set a non-zero `Estimate` directly on the epic, `Remaining Work` becomes required (the same as for any regular issue with an estimate).
+
 **Example:**
 ```
 Epic: Implement User Authentication (Estimate: 0)
@@ -316,6 +318,7 @@ Total feature estimate: 6 weeks (sum of sub-issues)
 Sometimes an Epic requires work that isn't captured in any sub-issue (e.g., minor coordination tasks, quick documentation updates). In this case:
 
 - **Estimate**: `> 0` (only for work specific to the Epic itself)
+- **Remaining Work**: required — once a non-zero estimate is set on the epic, the `NO_REMAINING_WORK` alert will fire if this field is empty
 - Track time for Epic-specific work separately from sub-issues
 
 **Important:** If the Epic-specific work has enough substance or complexity, **create a dedicated sub-issue for it** instead of tracking it directly on the Epic. This provides better granularity and makes the work more visible.


### PR DESCRIPTION
## Summary

Epics (GitHub issues or JIRA issues that have sub-issues / sub-tasks) were incorrectly subject to the same validation alerts as regular issues. This caused two spurious alert behaviours:

- `NO_ESTIMATE` was raised for epics even though estimate is optional for them.
- `NO_REMAINING_WORK` was raised for epics regardless of whether an estimate had been set on the epic itself.

## Changes

### Rule changes (identical semantics in both GH and JIRA checkers)

| Rule | Before | After |
|---|---|---|
| `NO_ESTIMATE` | Raised for any non-backlog/non-next item with no estimate | **Suppressed entirely for epics** |
| `NO_REMAINING_WORK` | Raised for any in-progress/in-review item with no remaining work | **Suppressed for epics whose own estimate is ≤ 0**; still raised when the epic carries `estimate > 0` |

An **epic** is defined as any issue that has at least one sub-issue (GH: `subIssues.nodes` non-empty; JIRA: `fields.subtasks` non-empty).

### Files changed

| File | What changed |
|---|---|
| `gh-issues-compliance-checker.yml` | Derive `HAS_SUB_ISSUES` before rule block; add epic guard to `NO_ESTIMATE`; nest `NO_REMAINING_WORK` body inside epic-aware conditional |
| `scripts/policy-validator.js` | Add `isEpic()` helper; skip `originalEstimate` check for epics; skip `remainingEstimate` check for epics with `originalEstimateSeconds ≤ 0` |
| `scripts/gh-issues-compliance-checker.test.js` | Mirror rule changes in `evalRule`'s inline bash; add 4 new tests |
| `scripts/policy-validator.test.js` | Add `subtasks` param to `makeIssue`; add 4 new tests |
| `gh-issues-compliance-checker.md` | Update alert codes table and troubleshooting entries for both rules |
| `jira-compliance-checker.md` | Update alert codes table |
| `jira-compliance-checker-spec.md` | Update field definitions table and alert codes table |
| `docs/user-guide-rms-projects.md` | Update alert codes table; add compliance-alert callout in Working with Epics section |

## Tests

All existing and new tests pass:

- `gh-issues-compliance-checker.test.js`: **73/73 pass** (4 new epic tests)
- `policy-validator.test.js`: **13/13 pass** (4 new epic tests)

New test cases cover:
- `NO_ESTIMATE` not raised for an epic with no estimate
- `NO_REMAINING_WORK` not raised for an epic with empty estimate
- `NO_REMAINING_WORK` not raised for an epic with `estimate = 0`
- `NO_REMAINING_WORK` raised for an epic when `estimate > 0` and remaining work is absent