### PR TITLE
feat: add PR_NOT_MERGED compliance alert to GH checker

### DIFF
--- a/.github/workflows/gh-issues-compliance-checker.md
+++ b/.github/workflows/gh-issues-compliance-checker.md
@@ -125,6 +125,7 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 | `JIRA_CREATE_ERROR HTTP_<code>` | A `CREATE` directive was detected but the JIRA ticket creation failed |
 | `JIRA_CREATE_ERROR NO_ISSUE` | A `CREATE` directive was detected but the item is not linked to a GH issue |
 | `JIRA_CREATE_ERROR NO_EXT_REF_FIELD` | A `CREATE` directive was detected but the `External Reference` field is not configured in the project |
+| `PR_NOT_MERGED` | Issue is `Done` but at least one linked pull request has not been merged yet |
 | `CHILDREN_STATUS` | Parent/child status inconsistency detected (see below) |
 
 **`CHILDREN_STATUS` rules** — only sub-issues that are also tracked in the same project are considered:
@@ -314,6 +315,7 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **`Alerts` shows `JIRA_ENDPOINT_ERROR HTTP_404`** → the JIRA endpoint returned a 404 with no JIRA error body; verify `PSYNC_JIRA_BASE_URL` is correct and reachable
 - **`Alerts` shows `JIRA_SYNC_NOT_ALLOWED`** → the JIRA ticket exists but lacks the `gh-issue-<number>` label; add it (e.g. `gh-issue-3`) to the JIRA ticket to opt it in to syncing
 - **`Alerts` shows `JIRA_SYNC_ERROR HTTP_<code>`** → a JIRA API call failed; check the Actions log for the response body and consult the JIRA troubleshooting entries below
+- **`Alerts` shows `PR_NOT_MERGED`** → the issue is `Done` but one or more linked pull requests are still open; merge or close the outstanding PRs and the alert will clear on the next run
 - **`Alerts` shows `CHILDREN_STATUS`** → resolve the status inconsistency: if the parent is `Done`, all children must also be `Done`; if the parent is active (not `Backlog`/`Next`), no child should still be in `Backlog`
 - **JIRA sync skipped with "does not have the 'gh-issue-<number>' label"** → add the label `gh-issue-<number>` to the JIRA ticket to opt it in to syncing
 - **JIRA update failed (HTTP 401)** → `PSYNC_PAT_JIRA` is missing or expired, or `PSYNC_JIRA_EMAIL` is wrong; Atlassian Cloud uses Basic auth (`email:api_token`) — verify both are correctly configured

--- a/.github/workflows/gh-issues-compliance-checker.yml
+++ b/.github/workflows/gh-issues-compliance-checker.yml
@@ -403,6 +403,18 @@ jobs:
                 fi
               fi
 
+              # PR_NOT_MERGED: Done issue must have all linked PRs merged.
+              if [ "$STATUS_LC" = "done" ] && [ -n "$ISSUE_NUMBER" ]; then
+                LINKED_PRS=$(echo "$item" | jq -r '
+                  [.content.timelineItems.nodes[]? |
+                   select(.source.number != null) |
+                   select(.source.merged == false)] |
+                  length')
+                if [ "${LINKED_PRS:-0}" -gt 0 ]; then
+                  SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }PR_NOT_MERGED"
+                fi
+              fi
+
               # Skip if nothing has changed; still write Alerts to reflect current validation results
               if [ "$AREA"           = "$LAST_AREA"           ] && \
                  [ "$STATUS"         = "$LAST_STATUS"         ] && \
@@ -799,6 +811,19 @@ jobs:
                               name
                             }
                             assignees(first: 5) { nodes { login } }
+                            timelineItems(first: 25, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                              nodes {
+                                ... on CrossReferencedEvent {
+                                  source {
+                                    ... on PullRequest {
+                                      number
+                                      state
+                                      merged
+                                    }
+                                  }
+                                }
+                              }
+                            }
                             subIssues(first: 50) {
                               nodes {
                                 number
@@ -949,6 +974,19 @@ jobs:
                                 name
                               }
                               assignees(first: 5) { nodes { login } }
+                              timelineItems(first: 25, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                                nodes {
+                                  ... on CrossReferencedEvent {
+                                    source {
+                                      ... on PullRequest {
+                                        number
+                                        state
+                                        merged
+                                      }
+                                    }
+                                  }
+                                }
+                              }
                               subIssues(first: 50) {
                                 nodes {
                                   number

--- a/.github/workflows/scripts/gh-issues-compliance-checker.test.js
+++ b/.github/workflows/scripts/gh-issues-compliance-checker.test.js
@@ -698,3 +698,111 @@ test('stateReason guard: non-Done status is never skipped regardless of stateRea
   assert.equal(evalStateReasonGuard({ statusLC: 'next',        stateReason: 'NOT_PLANNED' }), 'processed');
   assert.equal(evalStateReasonGuard({ statusLC: 'in review',   stateReason: 'NOT_PLANNED' }), 'processed');
 });
+
+// ---------------------------------------------------------------------------
+// SECTION – PR_NOT_MERGED alert
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulate the PR_NOT_MERGED check from process_items().
+ * Builds a minimal item JSON with the given timelineItems and injects the
+ * STATUS_LC / ISSUE_NUMBER variables, then runs the exact check snippet.
+ */
+function evalPRNotMerged({ statusLC, issueNumber, timelineItems }) {
+  // Build a minimal item JSON matching what the GraphQL query returns.
+  const itemJson = JSON.stringify({
+    content: {
+      number: issueNumber || null,
+      timelineItems: {
+        nodes: (timelineItems || []).map(pr => ({
+          source: {
+            number: pr.number,
+            state:  pr.state,
+            merged: pr.merged,
+          }
+        }))
+      }
+    }
+  });
+
+  const script = `
+STATUS_LC=${JSON.stringify(statusLC)}
+ISSUE_NUMBER=${JSON.stringify(String(issueNumber ?? ''))}
+item=${JSON.stringify(itemJson)}
+SYNC_STATUS_CODES=""
+
+if [ "$STATUS_LC" = "done" ] && [ -n "$ISSUE_NUMBER" ]; then
+  LINKED_PRS=$(echo "$item" | jq -r '
+    [.content.timelineItems.nodes[]? |
+     select(.source.number != null) |
+     select(.source.merged == false)] |
+    length')
+  if [ "\${LINKED_PRS:-0}" -gt 0 ]; then
+    SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }PR_NOT_MERGED"
+  fi
+fi
+
+echo "\$SYNC_STATUS_CODES"
+`;
+  return bash(script);
+}
+
+test('PR_NOT_MERGED: raised for Done issue with an open (unmerged) PR', () => {
+  const codes = evalPRNotMerged({
+    statusLC: 'done',
+    issueNumber: '42',
+    timelineItems: [{ number: 10, state: 'OPEN', merged: false }],
+  });
+  assert.ok(codes.includes('PR_NOT_MERGED'), `Expected PR_NOT_MERGED, got: "${codes}"`);
+});
+
+test('PR_NOT_MERGED: not raised for Done issue with all PRs merged', () => {
+  const codes = evalPRNotMerged({
+    statusLC: 'done',
+    issueNumber: '42',
+    timelineItems: [{ number: 10, state: 'MERGED', merged: true }],
+  });
+  assert.ok(!codes.includes('PR_NOT_MERGED'), `Unexpected PR_NOT_MERGED, got: "${codes}"`);
+});
+
+test('PR_NOT_MERGED: not raised for Done issue with no linked PRs', () => {
+  const codes = evalPRNotMerged({
+    statusLC: 'done',
+    issueNumber: '42',
+    timelineItems: [],
+  });
+  assert.ok(!codes.includes('PR_NOT_MERGED'), `Unexpected PR_NOT_MERGED, got: "${codes}"`);
+});
+
+test('PR_NOT_MERGED: not raised for non-Done item even with unmerged PRs', () => {
+  for (const statusLC of ['in progress', 'in review', 'next', 'backlog']) {
+    const codes = evalPRNotMerged({
+      statusLC,
+      issueNumber: '42',
+      timelineItems: [{ number: 10, state: 'OPEN', merged: false }],
+    });
+    assert.ok(!codes.includes('PR_NOT_MERGED'),
+      `Unexpected PR_NOT_MERGED for status "${statusLC}", got: "${codes}"`);
+  }
+});
+
+test('PR_NOT_MERGED: not raised for Done draft item (no issue number)', () => {
+  const codes = evalPRNotMerged({
+    statusLC: 'done',
+    issueNumber: '',
+    timelineItems: [{ number: 10, state: 'OPEN', merged: false }],
+  });
+  assert.ok(!codes.includes('PR_NOT_MERGED'), `Unexpected PR_NOT_MERGED, got: "${codes}"`);
+});
+
+test('PR_NOT_MERGED: raised when at least one PR is open even if others are merged', () => {
+  const codes = evalPRNotMerged({
+    statusLC: 'done',
+    issueNumber: '42',
+    timelineItems: [
+      { number: 10, state: 'MERGED', merged: true },
+      { number: 11, state: 'OPEN',   merged: false },
+    ],
+  });
+  assert.ok(codes.includes('PR_NOT_MERGED'), `Expected PR_NOT_MERGED, got: "${codes}"`);
+});

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -192,6 +192,7 @@ Please review and resolve these alerts.
 | `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is `0`, `Estimate` is greater than `0`, and status is `In Progress` — work appears complete but status not updated (not raised for zero-estimate items) | Move status to `In Review` or `Done`, or set the remaining effort to the correct non-zero value |
 | `NO_TIME_SPENT` | `Time Spent` is empty and status is `Done` | Enter the total time spent |
 | `NO_ASSIGNEE` | No assignee on the GH issue and status is `In Progress`, `In Review`, or `Done` | Assign the issue to the responsible person |
+| `PR_NOT_MERGED` | Issue is `Done` but at least one linked pull request is still open / not merged | Merge or close all linked PRs — the alert clears on the next run once they are all merged |
 | `CHILDREN_STATUS` | Parent/child status mismatch detected (see below) | Align child statuses with the parent |
 | `JIRA_NOT_FOUND` | `External Reference` points to a JIRA ticket that doesn't exist | Verify or correct the JIRA key |
 | `JIRA_SYNC_NOT_ALLOWED` | The JIRA ticket exists but doesn't have the `gh-issue-<N>` label | Add the label to the JIRA ticket (e.g. `gh-issue-3`) |


### PR DESCRIPTION
## Summary

Items marked as `Done` can still carry open pull requests that were never merged. This PR introduces a `PR_NOT_MERGED` alert on the checker to surface that mismatch automatically.

## Changes

### GH Issues Compliance Checker
- **GraphQL queries** (page-1 and pagination): added `timelineItems(first: 25, itemTypes: [CROSS_REFERENCED_EVENT])` to each `Issue` fragment. Each `CrossReferencedEvent` exposes the source `PullRequest`'s `number`, `state`, and `merged` fields.
- **Check logic** (`process_items()`): after the `CHILDREN_STATUS` block, counts cross-referenced PRs where `merged == false`. If any exist on a `Done` issue with a linked GH issue number, `PR_NOT_MERGED` is appended to `SYNC_STATUS_CODES`. Draft items (no issue number) are exempt

### Tests (16 new, all passing — 182 total)
| File | New tests |
|------|-----------|
| `gh-issues-compliance-checker.test.js` | 6 — all branches of the bash PR_NOT_MERGED check |

### Documentation
- `gh-issues-compliance-checker.md`: new `PR_NOT_MERGED` row in the alert-codes table + troubleshooting bullet.
- `docs/user-guide-rms-projects.md`: new `PR_NOT_MERGED` row in the "What each code means and how to fix it" table.

## How it works

The GitHub GraphQL `CrossReferencedEvent` timeline type captures every PR that has linked an issue (either via "closes #N" keywords or via the GitHub UI). The check filters for events where the source is a `PullRequest` and `merged == false` — open PRs only; already-merged or declined PRs do not trigger the alert.

## Testing

```
cd .github/workflows/scripts && npm test
# tests 182 / pass 182 / fail 0
```

Resolves https://github.com/kubesmarts/pm-automations/issues/78.