### PR TITLE
feat: add PR_NOT_MERGED compliance alert for Done-stage JIRA tickets

### DIFF
--- a/.github/workflows/jira-compliance-checker.md
+++ b/.github/workflows/jira-compliance-checker.md
@@ -82,6 +82,7 @@ Compliance alert codes:
 | `NO_TIME_SPENT` | Missing time spent |
 | `NO_ASSIGNEE` | Missing assignee |
 | `REMAINING_WORK_NOT_CLEARED` | Remaining work not cleared when Done (auto-cleared by the workflow) |
+| `PR_NOT_MERGED` | One or more GitHub PRs linked to the ticket are still open. Only checked for `RELEASE PENDING` and `CLOSED` (resolution: Done) tickets. PRs are fetched via the JIRA dev-status API |
 
 ### 4. Compliance Report
 A JSON report is generated with:
@@ -157,6 +158,11 @@ The workflow will:
 
 ### `ESTIMATE_TOO_LONG` violation on an issue
 - The original estimate on the JIRA ticket exceeds 2 weeks (10 business days) and the ticket is `In Progress`; consider breaking the work into smaller issues, or move it back to `Backlog` / `New` if the large estimate is intentional at this stage
+
+### `PR_NOT_MERGED` violation on an issue
+- One or more GitHub pull requests linked to the ticket are still open while the ticket is in `RELEASE PENDING` or `CLOSED` (Done) status
+- Merge or close the open PRs, then the alert will clear on the next workflow run
+- If the JIRA dev-status API is not available (e.g. the GitHub integration is not configured), the check is silently skipped — no false positives will be raised
 
 ### Workflow fails
 - Check **Actions** tab for error logs

--- a/.github/workflows/scripts/jira-client.js
+++ b/.github/workflows/scripts/jira-client.js
@@ -106,6 +106,29 @@ class JiraClient {
         return await this.makeRequest(`/rest/api/3/issue/${issueKey}?fields=${fields}`);
     }
 
+    /**
+     * Fetch linked pull requests for a JIRA issue via the dev-status API.
+     * Returns an array of PR objects: { id, title, url, status, state }.
+     * - status: 'OPEN' | 'MERGED' | 'DECLINED' (as returned by JIRA)
+     * Returns an empty array when the API is unavailable or no PRs are linked.
+     */
+    async fetchLinkedPullRequests(issueId) {
+        try {
+            const endpoint = `/rest/dev-status/1.0/issue/detail?issueId=${issueId}&applicationType=GitHub&dataType=pullrequest`;
+            const data = await this.makeRequest(endpoint);
+            const repos = data?.detail?.[0]?.pullRequests ?? [];
+            return repos.map(pr => ({
+                id: pr.id,
+                title: pr.name,
+                url: pr.url,
+                status: pr.status  // 'OPEN', 'MERGED', 'DECLINED'
+            }));
+        } catch (error) {
+            console.warn(`  ⚠️  Could not fetch linked PRs for issue ${issueId}: ${error.message}`);
+            return [];
+        }
+    }
+
     async updateIssueLabels(issueKey, labelsToAdd, labelsToRemove) {
         const issue = await this.fetchIssue(issueKey);
         const currentLabels = this.extractLabels(issue);

--- a/.github/workflows/scripts/jira-client.test.js
+++ b/.github/workflows/scripts/jira-client.test.js
@@ -130,3 +130,47 @@ test('extractComplianceAlerts: works when mention node precedes the text (real c
   const result = await client.extractComplianceAlerts('PROJ-6');
   assert.equal(result, 'NO_PRIORITY');
 });
+
+// ---------------------------------------------------------------------------
+// fetchLinkedPullRequests
+// ---------------------------------------------------------------------------
+
+test('fetchLinkedPullRequests: returns mapped PR objects from dev-status API', async () => {
+  const devStatusResponse = {
+    detail: [{
+      pullRequests: [
+        { id: '1', name: 'Fix bug', url: 'https://github.com/org/repo/pull/1', status: 'MERGED' },
+        { id: '2', name: 'Add feature', url: 'https://github.com/org/repo/pull/2', status: 'OPEN' },
+      ]
+    }]
+  };
+  const client = makeClient(async () => devStatusResponse);
+  const prs = await client.fetchLinkedPullRequests('10001');
+  assert.equal(prs.length, 2);
+  assert.equal(prs[0].status, 'MERGED');
+  assert.equal(prs[1].status, 'OPEN');
+  assert.equal(prs[1].url, 'https://github.com/org/repo/pull/2');
+});
+
+test('fetchLinkedPullRequests: returns empty array when no PRs linked', async () => {
+  const client = makeClient(async () => ({ detail: [{ pullRequests: [] }] }));
+  const prs = await client.fetchLinkedPullRequests('10002');
+  assert.deepEqual(prs, []);
+});
+
+test('fetchLinkedPullRequests: returns empty array when detail is absent', async () => {
+  const client = makeClient(async () => ({}));
+  const prs = await client.fetchLinkedPullRequests('10003');
+  assert.deepEqual(prs, []);
+});
+
+test('fetchLinkedPullRequests: returns empty array and warns on API error', async () => {
+  const client = makeClient(async () => { throw new Error('403 Forbidden'); });
+  const warnings = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  const prs = await client.fetchLinkedPullRequests('10004');
+  console.warn = origWarn;
+  assert.deepEqual(prs, []);
+  assert.ok(warnings.some(w => w.includes('10004')));
+});

--- a/.github/workflows/scripts/jira-compliance-checker.js
+++ b/.github/workflows/scripts/jira-compliance-checker.js
@@ -97,8 +97,20 @@ async function main() {
                 continue;
             }
 
+            // Fetch open PRs for Done-stage issues (needed for PR_NOT_MERGED check)
+            let openPullRequests = [];
+            const preCheckStage = policyValidator.mapStatusToPolicyStage(jiraClient.extractStatus(issue));
+            if (preCheckStage === 'Done') {
+                const issueId = issue.id;
+                const allPRs = await jiraClient.fetchLinkedPullRequests(issueId);
+                openPullRequests = allPRs.filter(pr => pr.status === 'OPEN');
+                if (openPullRequests.length > 0) {
+                    console.log(`  Open PRs: ${openPullRequests.length} (${openPullRequests.map(pr => pr.url).join(', ')})`);
+                }
+            }
+
             // Validate issue
-            const validationResult = policyValidator.validateIssue(issue, jiraClient);
+            const validationResult = policyValidator.validateIssue(issue, jiraClient, openPullRequests);
             console.log(`  Status: ${validationResult.status} (${validationResult.policyStage})`);
 
             // Auto-clear remaining estimate for Done issues

--- a/.github/workflows/scripts/policy-validator.js
+++ b/.github/workflows/scripts/policy-validator.js
@@ -91,7 +91,7 @@ class PolicyValidator {
         return Array.isArray(issue.fields.subtasks) && issue.fields.subtasks.length > 0;
     }
 
-    validateIssue(issue, jiraClient) {
+    validateIssue(issue, jiraClient, openPullRequests = []) {
         const status = jiraClient.extractStatus(issue);
         const policyStage = this.mapStatusToPolicyStage(status);
         const requiredFields = this.requiredFields[policyStage] || [];
@@ -140,6 +140,11 @@ class PolicyValidator {
         // Special check: Remaining Work should be cleared when Done
         if (policyStage === 'Done' && fieldValues.remainingEstimate) {
             violations.push('REMAINING_WORK_NOT_CLEARED');
+        }
+
+        // PR_NOT_MERGED: Done issues must have all linked PRs merged
+        if (policyStage === 'Done' && openPullRequests.length > 0) {
+            violations.push('PR_NOT_MERGED');
         }
 
         // ESTIMATE_TOO_LONG: estimate is set but exceeds 2 weeks, only for In Progress

--- a/.github/workflows/scripts/policy-validator.test.js
+++ b/.github/workflows/scripts/policy-validator.test.js
@@ -191,3 +191,78 @@ test('NO_REMAINING_WORK: raised for In Progress epic when estimate > 0 and remai
     assert.ok(result.violations.includes('NO_REMAINING_WORK'),
         `Expected NO_REMAINING_WORK for epic with estimate>0 and no remaining: ${result.violations}`);
 });
+
+// ---------------------------------------------------------------------------
+// PR_NOT_MERGED tests
+// ---------------------------------------------------------------------------
+
+/**
+ * A "Done" issue — RELEASE PENDING has all required fields populated via makeIssue defaults.
+ * We must also set timeSpent so NO_TIME_SPENT doesn't fire.
+ */
+function makeDoneIssue(overrides = {}) {
+    const issue = makeIssue({ status: 'RELEASE PENDING', estimateSeconds: ONE_WEEK_S, ...overrides });
+    // timetracking already has timeSpentSeconds > 0 when estimateSeconds is set
+    return issue;
+}
+
+const OPEN_PR   = { id: '1', title: 'Fix bug', url: 'https://github.com/org/repo/pull/1', status: 'OPEN' };
+const MERGED_PR = { id: '2', title: 'Add feature', url: 'https://github.com/org/repo/pull/2', status: 'MERGED' };
+
+test('PR_NOT_MERGED: raised for RELEASE PENDING issue with at least one open PR', () => {
+    const validator = new PolicyValidator();
+    const issue = makeDoneIssue();
+    const result = validator.validateIssue(issue, jiraClient, [OPEN_PR]);
+    assert.ok(result.violations.includes('PR_NOT_MERGED'),
+        `Expected PR_NOT_MERGED, got: ${result.violations}`);
+});
+
+test('PR_NOT_MERGED: raised for CLOSED/Done issue with at least one open PR', () => {
+    const validator = new PolicyValidator();
+    const issue = makeIssue({ status: 'CLOSED', estimateSeconds: ONE_WEEK_S });
+    issue.fields.resolution = { name: 'Done' };
+    const result = validator.validateIssue(issue, jiraClient, [OPEN_PR]);
+    assert.ok(result.violations.includes('PR_NOT_MERGED'),
+        `Expected PR_NOT_MERGED for CLOSED/Done, got: ${result.violations}`);
+});
+
+test('PR_NOT_MERGED: not raised when all linked PRs are merged (empty open-PR list)', () => {
+    const validator = new PolicyValidator();
+    const issue = makeDoneIssue();
+    // Caller filters to open PRs only; passing empty list simulates all-merged
+    const result = validator.validateIssue(issue, jiraClient, []);
+    assert.ok(!result.violations.includes('PR_NOT_MERGED'),
+        `Unexpected PR_NOT_MERGED when all PRs merged: ${result.violations}`);
+});
+
+test('PR_NOT_MERGED: not raised when there are no linked PRs', () => {
+    const validator = new PolicyValidator();
+    const issue = makeDoneIssue();
+    const result = validator.validateIssue(issue, jiraClient, []);
+    assert.ok(!result.violations.includes('PR_NOT_MERGED'),
+        `Unexpected PR_NOT_MERGED with no PRs: ${result.violations}`);
+});
+
+test('PR_NOT_MERGED: not raised when openPullRequests parameter is omitted', () => {
+    const validator = new PolicyValidator();
+    const issue = makeDoneIssue();
+    const result = validator.validateIssue(issue, jiraClient);
+    assert.ok(!result.violations.includes('PR_NOT_MERGED'),
+        `Unexpected PR_NOT_MERGED when parameter omitted: ${result.violations}`);
+});
+
+test('PR_NOT_MERGED: not raised for In Progress issues even with open PRs', () => {
+    const validator = new PolicyValidator();
+    const issue = makeIssue({ status: 'IN PROGRESS', estimateSeconds: ONE_WEEK_S });
+    const result = validator.validateIssue(issue, jiraClient, [OPEN_PR]);
+    assert.ok(!result.violations.includes('PR_NOT_MERGED'),
+        `Unexpected PR_NOT_MERGED for In Progress: ${result.violations}`);
+});
+
+test('PR_NOT_MERGED: raised with mixed open and merged PRs (at least one open)', () => {
+    const validator = new PolicyValidator();
+    const issue = makeDoneIssue();
+    const result = validator.validateIssue(issue, jiraClient, [MERGED_PR, OPEN_PR]);
+    assert.ok(result.violations.includes('PR_NOT_MERGED'),
+        `Expected PR_NOT_MERGED with mixed PRs, got: ${result.violations}`);
+});


### PR DESCRIPTION
## Summary

Implements [#92](https://github.com/kubesmarts/pm-automations/issues/92).

Introduces a new `PR_NOT_MERGED` alert in the JIRA compliance checker: tickets in `RELEASE PENDING` or `CLOSED` (resolution: Done) status must have **all linked GitHub PRs merged** before they are considered truly done.

## Changes

### `jira-client.js`
- Added `fetchLinkedPullRequests(issueId)`: queries the JIRA dev-status API (`/rest/dev-status/1.0/issue/detail`) to retrieve GitHub PRs linked to a ticket. Returns `[]` silently when the API is unavailable or the GitHub integration is not configured — no false positives.

### `policy-validator.js`
- Extended `validateIssue(issue, jiraClient, openPullRequests = [])` with an optional third parameter (backward-compatible default `[]`).
- Raises `PR_NOT_MERGED` when the issue is in the `Done` policy stage and at least one open PR is in the list.

### `jira-compliance-checker.js`
- For every Done-stage issue, fetches linked PRs, filters to `OPEN` ones, and passes them to `validateIssue`.

### Tests
- 4 new tests for `fetchLinkedPullRequests` in `jira-client.test.js`
- 7 new tests for `PR_NOT_MERGED` in `policy-validator.test.js`
- **All 178 tests pass**

### Docs
- `jira-compliance-checker.md`: added `PR_NOT_MERGED` to the alert-codes table and a troubleshooting section.

## Behaviour

| Condition | Result |
|-----------|--------|
| Done ticket, 1+ open PRs | `PR_NOT_MERGED` raised |
| Done ticket, all PRs merged | No alert |
| Done ticket, no linked PRs | No alert |
| Non-Done ticket, open PRs | No alert |
| Dev-status API unavailable | No alert (silently skipped) |

Closes #92