### PR TITLE
feat: add NO_DESCRIPTION alert to GH compliance checker

### DIFF
--- a/.github/workflows/gh-issues-compliance-checker.md
+++ b/.github/workflows/gh-issues-compliance-checker.md
@@ -125,6 +125,7 @@ When the optional `Alerts` field is present in a project, the workflow writes on
 | `JIRA_CREATE_ERROR HTTP_<code>` | A `CREATE` directive was detected but the JIRA ticket creation failed |
 | `JIRA_CREATE_ERROR NO_ISSUE` | A `CREATE` directive was detected but the item is not linked to a GH issue |
 | `JIRA_CREATE_ERROR NO_EXT_REF_FIELD` | A `CREATE` directive was detected but the `External Reference` field is not configured in the project |
+| `NO_DESCRIPTION` | Issue body is empty **and** the item is either an epic (has sub-issues) **or** has an `Estimate` ≥ 4 hours (`0.1` weeks). Items with no estimate or an estimate smaller than 4 hours are not checked. |
 | `PR_NOT_MERGED` | Issue is `Done` but at least one linked pull request has not been merged yet |
 | `CHILDREN_STATUS` | Parent/child status inconsistency detected (see below) |
 
@@ -316,6 +317,7 @@ Change a field that is **not** tracked (e.g. title or assignee). After the next 
 - **`Alerts` shows `JIRA_SYNC_NOT_ALLOWED`** → the JIRA ticket exists but lacks the `gh-issue-<number>` label; add it (e.g. `gh-issue-3`) to the JIRA ticket to opt it in to syncing
 - **`Alerts` shows `JIRA_SYNC_ERROR HTTP_<code>`** → a JIRA API call failed; check the Actions log for the response body and consult the JIRA troubleshooting entries below
 - **`Alerts` shows `PR_NOT_MERGED`** → the issue is `Done` but one or more linked pull requests are still open; merge or close the outstanding PRs and the alert will clear on the next run
+- **`Alerts` shows `NO_DESCRIPTION`** → add a description to the GitHub issue body. This alert fires when the issue has no body and is either a parent issue (has sub-issues) or has an `Estimate` of 4 hours (`0.1` weeks) or more. Small issues with no estimate or a sub-4-hour estimate are exempt.
 - **`Alerts` shows `CHILDREN_STATUS`** → resolve the status inconsistency: if the parent is `Done`, all children must also be `Done`; if the parent is active (not `Backlog`/`Next`), no child should still be in `Backlog`
 - **JIRA sync skipped with "does not have the 'gh-issue-<number>' label"** → add the label `gh-issue-<number>` to the JIRA ticket to opt it in to syncing
 - **JIRA update failed (HTTP 401)** → `PSYNC_PAT_JIRA` is missing or expired, or `PSYNC_JIRA_EMAIL` is wrong; Atlassian Cloud uses Basic auth (`email:api_token`) — verify both are correctly configured

--- a/.github/workflows/gh-issues-compliance-checker.yml
+++ b/.github/workflows/gh-issues-compliance-checker.yml
@@ -242,6 +242,8 @@ jobs:
 
               # Determine whether this item is an epic (has at least one sub-issue in the graph).
               HAS_SUB_ISSUES=$(echo "$item" | jq -r 'if (.content.subIssues.nodes // [] | length) > 0 then "true" else "false" end')
+              # Extract issue body/description (empty string if absent or not an issue).
+              ISSUE_BODY=$(echo "$item" | jq -r '.content.body // ""')
 
               # Handle JIRA ticket creation if External Reference is a CREATE directive.
               # Pattern: "CREATE <projectKey> [<component>]"  e.g. "CREATE QUARKUS quarkus-flow"
@@ -368,6 +370,16 @@ jobs:
               if { [ "$STATUS_LC" = "in progress" ] || [ "$STATUS_LC" = "in review" ] || [ "$STATUS_LC" = "done" ]; } && \
                  [ "$HAS_ASSIGNEE" != "true" ]; then
                 SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_ASSIGNEE"
+              fi
+              # NO_DESCRIPTION: raised when:
+              #   - item is an epic (has sub-issues), OR
+              #   - item has an estimate >= 4 hours (0.1 weeks)
+              # AND the issue body is empty. Items with no estimate (< 4h) are skipped.
+              if [ -z "$ISSUE_BODY" ]; then
+                if [ "$HAS_SUB_ISSUES" = "true" ] || \
+                   { [ -n "$ESTIMATE" ] && awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 >= 0.1) }'; }; then
+                  SYNC_STATUS_CODES="${SYNC_STATUS_CODES:+${SYNC_STATUS_CODES}, }NO_DESCRIPTION"
+                fi
               fi
 
               # Check CHILDREN_STATUS: detect parent/child status inconsistencies.
@@ -808,6 +820,7 @@ jobs:
                             number
                             title
                             url
+                            body
                             stateReason
                             repository {
                               owner { login }
@@ -972,6 +985,7 @@ jobs:
                               number
                               title
                               url
+                              body
                               stateReason
                               repository {
                                 owner { login }

--- a/.github/workflows/scripts/gh-issues-compliance-checker.test.js
+++ b/.github/workflows/scripts/gh-issues-compliance-checker.test.js
@@ -236,6 +236,15 @@ if [ -n "$ESTIMATE_FIELD_ID" ] && [ "$STATUS_LC" = "in progress" ] && [ -n "$EST
   SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }ESTIMATE_TOO_LONG"
 fi
 
+# NO_DESCRIPTION: raised when body is empty AND (item is epic OR estimate >= 0.1 weeks / 4 hours).
+# Items with no estimate or estimate < 0.1 are skipped.
+if [ -z "$ISSUE_BODY" ]; then
+  if [ "$HAS_SUB_ISSUES" = "true" ] || \
+     { [ -n "$ESTIMATE" ] && awk -v e="$ESTIMATE" 'BEGIN { exit !(e+0 >= 0.1) }'; }; then
+    SYNC_STATUS_CODES="\${SYNC_STATUS_CODES:+\${SYNC_STATUS_CODES}, }NO_DESCRIPTION"
+  fi
+fi
+
 echo "\$SYNC_STATUS_CODES"
 `;
   return bash(script);
@@ -484,6 +493,43 @@ test('ESTIMATE_TOO_LONG: not raised when estimate is absent (NO_ESTIMATE handles
   assert.ok(!codes.includes('ESTIMATE_TOO_LONG'), `Unexpected ESTIMATE_TOO_LONG for empty estimate: "${codes}"`);
 });
 
+// -- NO_DESCRIPTION --
+
+test('NO_DESCRIPTION: raised for epic with empty body', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'true', ISSUE_BODY: '' });
+  assert.ok(codes.includes('NO_DESCRIPTION'), `Expected NO_DESCRIPTION for epic with no body: "${codes}"`);
+});
+
+test('NO_DESCRIPTION: not raised for epic with a non-empty body', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'true', ISSUE_BODY: 'Some description.' });
+  assert.ok(!codes.includes('NO_DESCRIPTION'), `Unexpected NO_DESCRIPTION for epic with body: "${codes}"`);
+});
+
+test('NO_DESCRIPTION: raised for non-epic with estimate >= 0.1 (4h) and empty body', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'false', ESTIMATE: '0.1', ISSUE_BODY: '' });
+  assert.ok(codes.includes('NO_DESCRIPTION'), `Expected NO_DESCRIPTION for estimate=0.1 with no body: "${codes}"`);
+});
+
+test('NO_DESCRIPTION: raised for non-epic with estimate > 0.1 and empty body', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'false', ESTIMATE: '1', ISSUE_BODY: '' });
+  assert.ok(codes.includes('NO_DESCRIPTION'), `Expected NO_DESCRIPTION for estimate=1 with no body: "${codes}"`);
+});
+
+test('NO_DESCRIPTION: not raised for non-epic with estimate < 0.1 (< 4h) and empty body', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'false', ESTIMATE: '0.05', ISSUE_BODY: '' });
+  assert.ok(!codes.includes('NO_DESCRIPTION'), `Unexpected NO_DESCRIPTION for estimate=0.05: "${codes}"`);
+});
+
+test('NO_DESCRIPTION: not raised when estimate is absent and item is not an epic', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'false', ESTIMATE: '', ISSUE_BODY: '' });
+  assert.ok(!codes.includes('NO_DESCRIPTION'), `Unexpected NO_DESCRIPTION with no estimate and not epic: "${codes}"`);
+});
+
+test('NO_DESCRIPTION: not raised for non-epic with estimate >= 0.1 when body is present', () => {
+  const codes = evalRule({ ...ALL_FIELDS, HAS_SUB_ISSUES: 'false', ESTIMATE: '0.5', ISSUE_BODY: 'Implement the new feature.' });
+  assert.ok(!codes.includes('NO_DESCRIPTION'), `Unexpected NO_DESCRIPTION when body is present: "${codes}"`);
+});
+
 // -- Multiple alerts at once --
 
 test('multiple alerts: all applicable codes raised for a done item missing area, time spent', () => {
@@ -502,6 +548,7 @@ test('clean item: no alerts for a fully-populated in-progress item', () => {
     ESTIMATE:      '1',
     REMAINING_WORK:'0.5',
     TIME_SPENT:    '',   // TIME_SPENT only required for done
+    ISSUE_BODY:    'Implement the new feature as described in the spec.',
   });
   assert.equal(codes, '', `Expected no alerts, got: "${codes}"`);
 });

--- a/docs/user-guide-rms-projects.md
+++ b/docs/user-guide-rms-projects.md
@@ -79,6 +79,7 @@ The issue is actively being worked on. All planning fields must be filled in and
 | `Remaining Work` | **Yes** | Alerts: `NO_REMAINING_WORK` |
 | `Time Spent` | Update regularly | Will be required at `Done` |
 | Assignee (GH issue) | **Yes** | Alerts: `NO_ASSIGNEE` |
+| Issue body (description) | **Yes, if Estimate ≥ 4h** | Alerts: `NO_DESCRIPTION` |
 
 Keep `Remaining Work` up to date as you make progress. It represents how much work is left, not how much you've done.
 
@@ -192,6 +193,7 @@ Please review and resolve these alerts.
 | `IN_PROGRESS_NO_WORK_REMAINING` | `Remaining Work` is `0`, `Estimate` is greater than `0`, and status is `In Progress` — work appears complete but status not updated (not raised for zero-estimate items) | Move status to `In Review` or `Done`, or set the remaining effort to the correct non-zero value |
 | `NO_TIME_SPENT` | `Time Spent` is empty and status is `Done` | Enter the total time spent |
 | `NO_ASSIGNEE` | No assignee on the GH issue and status is `In Progress`, `In Review`, or `Done` | Assign the issue to the responsible person |
+| `NO_DESCRIPTION` | The GitHub issue body is empty **and** the item is either an epic (has sub-issues) or has an `Estimate` ≥ 4 hours (`0.1` weeks). Items with no estimate or an estimate below 4 hours are exempt | Add a description to the GitHub issue body |
 | `PR_NOT_MERGED` | Issue is `Done` but at least one linked pull request is still open / not merged | Merge or close all linked PRs — the alert clears on the next run once they are all merged |
 | `CHILDREN_STATUS` | Parent/child status mismatch detected (see below) | Align child statuses with the parent |
 | `JIRA_NOT_FOUND` | `External Reference` points to a JIRA ticket that doesn't exist | Verify or correct the JIRA key |
@@ -302,7 +304,7 @@ Most Epics serve purely as organizational containers. In this case:
 
 All time tracking should be done in the sub-issues. The Epic itself has no work associated with it.
 
-> **Compliance alerts:** The workflow automatically suppresses `NO_ESTIMATE` for all epics — estimate is optional. `NO_REMAINING_WORK` is also suppressed when the epic's own `Estimate` is `0` or empty. If you set a non-zero `Estimate` directly on the epic, `Remaining Work` becomes required (the same as for any regular issue with an estimate).
+> **Compliance alerts:** The workflow automatically suppresses `NO_ESTIMATE` for all epics — estimate is optional. `NO_REMAINING_WORK` is also suppressed when the epic's own `Estimate` is `0` or empty. If you set a non-zero `Estimate` directly on the epic, `Remaining Work` becomes required (the same as for any regular issue with an estimate). `NO_DESCRIPTION` is always enforced for epics — all epics must have a non-empty issue body regardless of estimate.
 
 **Example:**
 ```


### PR DESCRIPTION
## Summary

Introduces a new `NO_DESCRIPTION` alert in the GH Issues Compliance Checker workflow.

## Problem

Issues were being tracked without enough context for contributors — there was no enforcement of non-empty descriptions on items that warrant it.

## Solution

Raise `NO_DESCRIPTION` when a GitHub issue has an empty body **and** at least one of the following is true:

- The item is an **epic** (has sub-issues / child issues)
- The item has an **Estimate ≥ 4 hours** (`0.1` weeks)

Items with no estimate or an estimate below 4 hours are exempt — the 4-hour threshold acts as a proxy for non-trivial work.

## Changes

| File | Change |
|------|--------|
| `gh-issues-compliance-checker.yml` | Fetch `body` via GraphQL (both initial page + pagination queries); extract `ISSUE_BODY`; add `NO_DESCRIPTION` validation rule after `NO_ASSIGNEE` |
| `gh-issues-compliance-checker.test.js` | Add `NO_DESCRIPTION` rule to `evalRule()`; add 7 new tests covering all policy branches; update the "clean item" baseline test to supply `ISSUE_BODY` |
| `gh-issues-compliance-checker.md` | Document `NO_DESCRIPTION` in the alerts table and troubleshooting section |

## Tests

All 225 tests pass (`npm test` in `.github/workflows/scripts/`).

Closes #77